### PR TITLE
fix: add Deepgram flush grace period before WebSocket disconnect

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1271,7 +1271,11 @@ async function handleCallEnd(tabId?: number) {
       console.warn('⚠️ [Background] Offscreen document may already be closed')
     })
 
-    // 2. Disconnect AI Backend
+    // 2. Grace period for Deepgram to flush final audio chunk
+    console.log('⏳ [Background] Waiting 2.5s for Deepgram to flush final transcripts...')
+    await new Promise(resolve => setTimeout(resolve, 2500))
+
+    // 3. Disconnect AI Backend
     await disconnectAIBackend()
 
     // 3. Close offscreen document


### PR DESCRIPTION
## Summary

Fixes race condition in handleCallEnd() where the AI backend WebSocket was disconnected immediately after STOP_CAPTURE, before Deepgram could flush the final audio chunk. The last 1-3 seconds of every call transcript was silently dropped.

## Change

Added a 2.5s grace period between STOP_CAPTURE and disconnectAIBackend() in src/background/index.ts to allow Deepgram to finalize and deliver the last isFinal transcript.

## Files Changed

- src/background/index.ts - handleCallEnd() (1 line added)

Closes #54