### PR TITLE
feat(prompt): reframe Bob as senior designer, agent as assistant (v2.2.4)

### DIFF
--- a/infra/lib/lambda/shared/claude-client-optimized.ts
+++ b/infra/lib/lambda/shared/claude-client-optimized.ts
@@ -62,12 +62,12 @@ export interface AITipResponse {
 // ============================================================================
 
 const SCRIPTS_GREETING = `## GREETING
-1. Basic Intro [ID: intro-basic]: "My name is [Agent], and Bob and I are here; we're local website designers here in [Location]. Do you currently have a website for your business, or is this something you've been thinking about?"
+1. Basic Intro [ID: intro-basic]: "My name is [Agent], Bob and I are local website designers here in [Location]. Do you currently have a website for your business, or is this something you've been thinking about?"
    → USE WHEN: Customer asks "Who is this?" or "Who are you?" or at start of call
    → ALWAYS end the intro with a question so the agent has a natural follow-up.
 2. Familiar Opener: "Good morning again, can you hear me okay?"
 3. Targeted Opener: "Good morning, is [Name] available please?"
-4. Quick Intro: "Real quick though, my name is [Agent], and Bob and I are here; we're local website designers here in [Location]. What kind of business do you run, if you don't mind me asking?"
+4. Quick Intro: "Real quick though, my name is [Agent], Bob and I are local website designers here in [Location]. What kind of business do you run, if you don't mind me asking?"
    → ALWAYS end with a question.
 5. Bob Transition (skip name): "Bob and I are local website designers here in [Location]. What kind of business do you run, if you don't mind me asking?"
    → USE WHEN: Agent already introduced themselves by name — skip repeating the name, just bring up Bob.`;

--- a/infra/lib/lambda/shared/claude-client-optimized.ts
+++ b/infra/lib/lambda/shared/claude-client-optimized.ts
@@ -62,14 +62,14 @@ export interface AITipResponse {
 // ============================================================================
 
 const SCRIPTS_GREETING = `## GREETING
-1. Basic Intro [ID: intro-basic]: "My name is [Agent], and my partner Bob and I are here; we're local website designers here in [Location]. Do you currently have a website for your business, or is this something you've been thinking about?"
+1. Basic Intro [ID: intro-basic]: "My name is [Agent], and Bob and I are here; we're local website designers here in [Location]. Do you currently have a website for your business, or is this something you've been thinking about?"
    → USE WHEN: Customer asks "Who is this?" or "Who are you?" or at start of call
    → ALWAYS end the intro with a question so the agent has a natural follow-up.
 2. Familiar Opener: "Good morning again, can you hear me okay?"
 3. Targeted Opener: "Good morning, is [Name] available please?"
-4. Quick Intro: "Real quick though, my name is [Agent], and my partner Bob and I are here; we're local website designers here in [Location]. What kind of business do you run, if you don't mind me asking?"
+4. Quick Intro: "Real quick though, my name is [Agent], and Bob and I are here; we're local website designers here in [Location]. What kind of business do you run, if you don't mind me asking?"
    → ALWAYS end with a question.
-5. Bob Transition (skip name): "My partner Bob and I are local website designers here in [Location]. What kind of business do you run, if you don't mind me asking?"
+5. Bob Transition (skip name): "Bob and I are local website designers here in [Location]. What kind of business do you run, if you don't mind me asking?"
    → USE WHEN: Agent already introduced themselves by name — skip repeating the name, just bring up Bob.`;
 
 const SCRIPTS_VALUE_PROP = `## VALUE PROPOSITION
@@ -83,14 +83,14 @@ const SCRIPTS_OBJECTION = `## OBJECTION HANDLING
 1. Have One/Busy [ID: obj-busy-or-have]: "You already got one though, or just busy right now to talk about it?"
    → USE WHEN: Customer says "We already have a website" or "I already have one" or "Not right now" or "Not at the moment"
    → DO NOT use when customer says "Not interested" or "I don't need a website" — see Respect Decline script below
-2. SEO Pivot: "That's great because we also optimize websites as well, especially with SEO, at super affordable costs. Would you mind if my partner Bob gives you a quick call to go over what we can do?"
+2. SEO Pivot: "That's great because we also optimize websites as well, especially with SEO, at super affordable costs. Would you mind if Bob gives you a quick call to go over what we can do?"
    → USE WHEN: Customer says they HAVE a website (positive tone). NOT when they describe a problem — use SEO Problem Empathy instead.
-3. SEO Affirmation: "Yeah, that's great that you already have one because we also optimize websites as well, especially with SEO. Would you mind if my partner Bob gives you a quick call later?"
-4. SEO Problem Empathy: "Oh, I hear you — SEO can be tricky. That's actually what we specialize in. Would you mind if my partner Bob gives you a quick call to walk you through some options?"
+3. SEO Affirmation: "Yeah, that's great that you already have one because we also optimize websites as well, especially with SEO. Would you mind if Bob gives you a quick call later?"
+4. SEO Problem Empathy: "Oh, I hear you — SEO can be tricky. That's actually what we specialize in. Would you mind if Bob gives you a quick call to walk you through some options?"
    → USE WHEN: Customer says their website has PROBLEMS (SEO, ranking, traffic). Empathize first — NEVER say "that's great" about a problem.
-5. Revamp Pivot: "Yeah, that's great that you already have a website because we also optimize or revamp them, especially with SEO. Would you mind if my partner Bob gives you a quick call later?"
-6. Digital Marketing Pivot: "Of course yeah. I was just about to say though [Name], we're a whole digital marketing company... and we can help you host, maintain or optimize it, especially with SEO. Would it be okay if my partner Bob gives you a quick call?"
-7. IP/Control Assurance: "Of course yeah. We definitely let our clienteles get full control of their own website. We believe in having it to all yourself and for your business. Would you mind if my partner Bob gives you a quick call to walk you through how that works?"
+5. Revamp Pivot: "Yeah, that's great that you already have a website because we also optimize or revamp them, especially with SEO. Would you mind if Bob gives you a quick call later?"
+6. Digital Marketing Pivot: "Of course yeah. I was just about to say though [Name], we're a whole digital marketing company... and we can help you host, maintain or optimize it, especially with SEO. Would it be okay if Bob gives you a quick call?"
+7. IP/Control Assurance: "Of course yeah. We definitely let our clienteles get full control of their own website. We believe in having it to all yourself and for your business. Would you mind if Bob gives you a quick call to walk you through how that works?"
 8. Respect Decline: "No problem. I do appreciate you taking my call. Have a great day."
    → USE WHEN: Customer says "I'm not interested", "I don't need a website", "No thanks", or any clear decline. Do NOT push back. Respect it and end the call politely.`;
 
@@ -106,9 +106,9 @@ const SCRIPTS_CLOSING = `## CLOSING
 8. Ask + FOMO: "Would you mind if I can have Bob or his partner give you a quick call later? Just don't want you to miss out."
 9. Confirm Authority: "You're the owner? [Name]? ... and you're the person in charge of the website to talk about later just to confirm?"
 10. Pricing/Samples: "Would you mind if I could have Bob or his partner give you a quick call later today to talk about pricing and all these samples?"
-11. Pricing Redirect: "We're super affordable — my partner Bob can get into the details with you on that, if you'd let him give you a quick call later today. Does that sound good?"
+11. Pricing Redirect: "We're super affordable — Bob can get into the details with you on that, if you'd let him give you a quick call later today. Does that sound good?"
    → USE WHEN: Customer asks about pricing or cost. Do NOT give specific numbers — pricing details are Bob's job.
-12. Timeline Redirect: "My partner Bob can walk you through the timeline — would you mind if he gives you a quick call later today? Does that sound good?"
+12. Timeline Redirect: "Bob can walk you through the timeline — would you mind if he gives you a quick call later today? Does that sound good?"
    → USE WHEN: Customer asks about how long it takes.`;
 
 const SCRIPTS_AI_RECEPTIONIST = `## AI RECEPTIONIST (when talking to an automated system or receptionist)
@@ -184,9 +184,13 @@ function getScriptsForStage(stage: string): string {
 // ULTRA-COMPRESSED SYSTEM PROMPT (OPTIMIZED FOR SPEED)
 // ============================================================================
 
-const SYSTEM_PROMPT_COMPRESSED = `Sales coach for local website design/SEO. Goal: get small business owner to agree to callback from agent's partner Bob.
+const SYSTEM_PROMPT_COMPRESSED = `Sales coach for local website design/SEO. Goal: get small business owner to agree to callback from Bob (senior designer agent assists).
 
-BOB: Agent's business partner — always "my partner Bob". He handles pricing, technical details, and client consultations.
+BOB: Senior local website designer. Agent is Bob's assistant. IDENTITY FRAMING:
+  - Default pitch/intro: "Bob and I are local website designers" (peer tone, never reveal hierarchy upfront)
+  - Direct identity question ("who are you?", "are you the owner?", "what's your role?", "are you Bob?"): honestly say "I'm Bob's assistant" or "I assist Bob with his clients"
+  - Never position Bob as a partner — always just "Bob" or "Bob and I"
+Bob handles pricing, technical details, and client consultations.
 
 OUTPUT FORMAT (exactly):
 [HEADING]: 2-word title
@@ -204,10 +208,11 @@ INTENT RULES (priority order):
    - Specific time given ("call at 4", "tomorrow") → acknowledge it, ask for email.
    - "Another time"/"busy right now" → ask WHEN, don't assume "later today".
 3. Customer FRUSTRATED ("going in circles", "you already said that", "not listening", "runaround", "level with me", "dancin' around") → STOP. Acknowledge briefly. Pivot to Ask Callback or answer their actual question.
-4. Pricing/cost/timeline asked → redirect to Bob: "We're super affordable — my partner Bob can get into the details. Would you mind if he gives you a quick call?"
-5. Features/capabilities asked → "Definitely, my partner Bob can show you exactly how that works — would he be able to give you a quick call?"
-6. Wrong number/confused → correct politely, re-introduce as local website designers.
+4. Pricing/cost/timeline asked → redirect to Bob: "We're super affordable — Bob can get into the details. Would you mind if he gives you a quick call?"
+5. Features/capabilities asked → "Definitely, Bob can show you exactly how that works — would he be able to give you a quick call?"
+6. Wrong number/confused → correct politely, re-introduce: "Bob and I are local website designers in [area]".
 7. "Who is this?" → Basic Intro (if not already introduced).
+7a. "Are you the owner?" / "What's your role?" / "Are you Bob?" / "Who are you really?" → honestly answer "I'm Bob's assistant, I help him connect with local businesses" — then pivot back to value or callback.
 8. Open invitation ("go ahead", "I'm listening", "tell me about it") → Bob Transition if intro done, else Quick Intro.
 9. "What do you need?" / "I'm busy" → Affordable Hook.
 10. "Already have a website" → problems/SEO issues: SEO Problem Empathy. Positive/neutral: Have One/Busy.
@@ -586,7 +591,7 @@ function getFallbackSuggestion(stage: string, latency: number): AITipResponse {
     objection: {
       heading: 'Handle Objection',
       stage: 'OBJECTION_HANDLING',
-      suggestion: "Would you mind if my partner Bob gives you a quick call later to talk about what we can do for your website?"
+      suggestion: "Would you mind if Bob gives you a quick call later to talk about what we can do for your website?"
     },
     closing: {
       heading: 'Ask Callback',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devassist-call-coach",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1203,7 +1203,7 @@ async function connectAIBackend() {
       {
         source: 'devassist-call-coach',
         tabId: extensionState.tabId,
-        version: '2.2.3',
+        version: '2.2.4',
       }
     )
 

--- a/tests/perf/verify-prompt-output.mjs
+++ b/tests/perf/verify-prompt-output.mjs
@@ -1,0 +1,214 @@
+/**
+ * Verify Identity Framing — Dumps FULL generated tips to verify prompt changes
+ */
+
+import { WebSocket } from 'ws';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '../..');
+
+function loadEnv() {
+  const envPath = resolve(PROJECT_ROOT, '.env.production');
+  const lines = readFileSync(envPath, 'utf-8').split('\n');
+  const env = {};
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    env[trimmed.slice(0, eqIdx)] = trimmed.slice(eqIdx + 1);
+  }
+  return env;
+}
+
+const env = loadEnv();
+const WS_URL = env.VITE_BACKEND_WS_URL || env.VITE_WS_URL;
+const API_KEY = env.VITE_BACKEND_API_KEY;
+
+// ── Test scenarios ──
+// Each scenario triggers a different prompt path to verify framing
+const SCENARIOS = [
+  {
+    name: 'GREETING — initial intro',
+    transcripts: [
+      { speaker: 'agent', text: "Hi is this [name] speaking?" },
+      { speaker: 'caller', text: "Yeah this is me, who's calling?" },
+    ],
+  },
+  {
+    name: 'OBJECTION — pricing redirect (was "my partner Bob")',
+    transcripts: [
+      { speaker: 'agent', text: "Hi, Bob and I are local website designers. Do you have a website?" },
+      { speaker: 'caller', text: "Maybe, how much does it cost though?" },
+    ],
+  },
+  {
+    name: 'IDENTITY CHALLENGE — "are you the owner?"',
+    transcripts: [
+      { speaker: 'agent', text: "My name is Mike, Bob and I are local website designers." },
+      { speaker: 'caller', text: "Wait, are you the owner? What's your role exactly?" },
+    ],
+  },
+  {
+    name: 'OBJECTION — features/capabilities',
+    transcripts: [
+      { speaker: 'agent', text: "We design websites for local businesses." },
+      { speaker: 'caller', text: "Do you also do SEO? How does that work exactly?" },
+    ],
+  },
+];
+
+function waitForMessage(ws, type, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.removeListener('message', handler);
+      reject(new Error(`Timeout waiting for ${type}`));
+    }, timeoutMs);
+    function handler(raw) {
+      try {
+        const data = JSON.parse(raw.toString());
+        if (data.type === type) {
+          clearTimeout(timer);
+          ws.removeListener('message', handler);
+          resolve(data);
+        }
+      } catch { /* ignore */ }
+    }
+    ws.on('message', handler);
+  });
+}
+
+function collectFullTip(ws, timeoutMs = 15000) {
+  return new Promise((resolve) => {
+    let fullText = '';
+    let metadata = {};
+    const timer = setTimeout(() => {
+      ws.removeListener('message', handler);
+      resolve({ fullText, ...metadata });
+    }, timeoutMs);
+
+    function handler(raw) {
+      try {
+        const data = JSON.parse(raw.toString());
+        if (data.type === 'TIP_CHUNK') {
+          fullText += data.payload?.delta || '';
+          if (data.payload?.heading) metadata.heading = data.payload.heading;
+          if (data.payload?.stage) metadata.stage = data.payload.stage;
+        }
+        if (data.type === 'AI_TIP' || data.type === 'INTELLIGENCE_UPDATE') {
+          setTimeout(() => {
+            clearTimeout(timer);
+            ws.removeListener('message', handler);
+            if (data.payload?.aiTip) {
+              metadata.finalStage = data.payload.aiTip.stage;
+              metadata.finalHeading = data.payload.aiTip.heading;
+              metadata.finalSuggestion = data.payload.aiTip.suggestion;
+            } else if (data.payload?.suggestion) {
+              metadata.finalSuggestion = data.payload.suggestion;
+            }
+            resolve({ fullText, ...metadata });
+          }, 200);
+        }
+      } catch { /* ignore */ }
+    }
+    ws.on('message', handler);
+  });
+}
+
+async function runScenario(ws, conversationId, scenario) {
+  console.log('\n' + '═'.repeat(70));
+  console.log(`  SCENARIO: ${scenario.name}`);
+  console.log('═'.repeat(70));
+
+  // Clear scenario by sending fresh transcripts
+  for (const t of scenario.transcripts) {
+    ws.send(JSON.stringify({
+      action: 'transcript',
+      conversationId,
+      speaker: t.speaker,
+      text: t.text,
+      isFinal: true,
+      timestamp: Date.now(),
+    }));
+    console.log(`  ${t.speaker.toUpperCase()}: "${t.text}"`);
+    await new Promise(r => setTimeout(r, 150));
+  }
+
+  await new Promise(r => setTimeout(r, 500));
+
+  const tipPromise = collectFullTip(ws);
+  ws.send(JSON.stringify({
+    action: 'getIntelligence',
+    conversationId,
+    skipTip: false,
+    skipIntelligence: false,
+    transcripts: scenario.transcripts,
+    timestamp: Date.now(),
+  }));
+
+  const result = await tipPromise;
+
+  console.log('\n  --- GENERATED TIP ---');
+  if (result.fullText) {
+    console.log(result.fullText);
+  } else if (result.finalSuggestion) {
+    console.log(`[Heading]: ${result.finalHeading}`);
+    console.log(`[Stage]: ${result.finalStage}`);
+    console.log(`[Script]: ${result.finalSuggestion}`);
+  }
+  console.log('  ---');
+}
+
+async function main() {
+  console.log('================================================================');
+  console.log('  Identity Framing Verification');
+  console.log('================================================================');
+
+  const ws = await new Promise((resolve, reject) => {
+    const url = `${WS_URL}?apiKey=${encodeURIComponent(API_KEY)}`;
+    const socket = new WebSocket(url);
+    socket.on('open', () => resolve(socket));
+    socket.on('error', (e) => reject(e));
+    setTimeout(() => reject(new Error('timeout')), 15000);
+  });
+
+  const startP = waitForMessage(ws, 'CONVERSATION_STARTED');
+  ws.send(JSON.stringify({
+    action: 'startConversation',
+    agentId: `verify-${Date.now()}`,
+    metadata: { timestamp: Date.now(), apiKey: API_KEY },
+  }));
+  const startResp = await startP;
+  const conversationId = startResp.payload.conversationId;
+  console.log(`Connected. Conversation: ${conversationId.slice(0, 8)}...`);
+
+  for (const scenario of SCENARIOS) {
+    try {
+      await runScenario(ws, conversationId, scenario);
+      await new Promise(r => setTimeout(r, 1000));
+    } catch (err) {
+      console.error(`  SCENARIO FAILED: ${err.message}`);
+    }
+  }
+
+  ws.send(JSON.stringify({ action: 'endConversation', conversationId, timestamp: Date.now() }));
+  await new Promise(r => setTimeout(r, 500));
+  ws.close(1000);
+
+  console.log('\n' + '═'.repeat(70));
+  console.log('  VERIFICATION CHECKLIST');
+  console.log('═'.repeat(70));
+  console.log('  [ ] No "my partner Bob" anywhere');
+  console.log('  [ ] Intros say "Bob and I are local website designers"');
+  console.log('  [ ] Pricing redirect says "Bob can get into the details"');
+  console.log('  [ ] Identity challenge acknowledges assistant role honestly');
+  console.log('');
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 const manifest: ManifestV3Export = {
   manifest_version: 3,
   name: "Simple.biz Call Coach",
-  version: "2.2.3",
+  version: "2.2.4",
   description: "Real-time AI-powered call coaching with AWS Lambda backend, conversation intelligence, and Developer Mode for offline testing",
   icons: {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary

Changes the AI coaching identity framing in the system prompt and golden scripts:
- **Default pitch/intro:** "Bob and I are local website designers" (peer tone)
- **Direct identity question** ("are you the owner?", "what's your role?", "are you Bob?"): honestly answer "I'm Bob's assistant"
- All "my partner Bob" references replaced with just "Bob" across 12 golden scripts
- New intent rule 7a added to handle identity challenges
- Fixed hallucination in intro scripts (removed awkward "are here; we're" double phrasing)
- Version bumped 2.2.3 → 2.2.4

## Why

Agent is Bob's assistant, but leading the pitch with "I'm an assistant" risks customers getting defensive about being handed off to an underling. Solution: soft-frame as peer-level designers upfront, but answer honestly when probed directly.

## Verification against production

Deployed to production Lambda and ran `tests/perf/verify-prompt-output.mjs` — verified clean output across 4 scenarios:

### Greeting intro (ran 3x to check hallucination fix)
```
"My name is [Agent], Bob and I are local website designers here in [Location].
Do you currently have a website for your business, or is this something
you've been thinking about?"
```
All 3 runs produced clean, coherent intros. No garbling.

### Pricing redirect (was "my partner Bob")
```
"We're super affordable — Bob can get into all the details with you.
Would you mind if he gives you a quick call..."
```

### Identity challenge ("are you the owner?")
```
"I'm Bob's assistant — I help him connect with local businesses here in
[Location]. Bob handles all the website design and details. Real quick
though, what kind of business do you run?"
```
Exactly what we wanted: honest, helpful, pivots back to engagement.

### Features/SEO question
```
"Yeah, absolutely — SEO is definitely something Bob handles. He can
walk you through exactly how that works..."
```

## The hallucination fix (commit 2)

During verification, the first test run produced a garbled intro:
> "Bob and I are local website building a website for your business"

Root cause: the golden script had awkward double-"here" structure:
> "Bob and I are here; we're local website designers here in [Location]"

The "are here; we're" was redundant verbal filler that made the sentence structure ambiguous. Simplified both Basic Intro and Quick Intro to match the already-clean Bob Transition pattern. Hallucination eliminated across 3 follow-up test runs.

## Files changed

- `infra/lib/lambda/shared/claude-client-optimized.ts` — system prompt + 12 golden scripts
- `package.json` — version bump
- `vite.config.ts` — manifest version
- `src/background/index.ts` — telemetry version
- `tests/perf/verify-prompt-output.mjs` — new prompt QA test (added)

## Deploy status

**Already deployed to production** (for verification testing). Merge to main is for history/versioning only.

## Test plan

- [x] Deployed to production via `cdk deploy DevAssist-WebSocket`
- [x] Verified greeting intro (3x runs, no hallucination)
- [x] Verified pricing redirect uses just "Bob"
- [x] Verified identity challenge returns honest assistant answer
- [x] Verified features/SEO redirect uses just "Bob"

## Rollback

```bash
git revert <commit>
cd infra && npx cdk deploy DevAssist-WebSocket
```
~3 min rollback.