### PR TITLE
fix(popup): close popup after sidebar opens (v2.2.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devassist-call-coach",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1203,7 +1203,7 @@ async function connectAIBackend() {
       {
         source: 'devassist-call-coach',
         tabId: extensionState.tabId,
-        version: '2.2.6',
+        version: '2.2.7',
       }
     )
 

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -275,6 +275,8 @@ export default function Popup() {
         try {
           await chrome.sidePanel.open({ windowId: tab.windowId })
           console.log('✅ [Popup] Side panel opened successfully')
+          // Close popup so agent doesn't re-click Start Coaching
+          window.close()
         } catch (sidePanelError) {
           console.warn('⚠️ [Popup] Could not open side panel:', sidePanelError)
           // Side panel might already be open, this is not critical

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 const manifest: ManifestV3Export = {
   manifest_version: 3,
   name: "Simple.biz Call Coach",
-  version: "2.2.6",
+  version: "2.2.7",
   description: "Real-time AI-powered call coaching with AWS Lambda backend, conversation intelligence, and Developer Mode for offline testing",
   icons: {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary

When an agent clicked "Start Coaching", the sidebar opened but the popup stayed visible with the Start Coaching button still there. Some agents clicked it again, triggering duplicate coaching starts.

**Fix:** Call `window.close()` after `chrome.sidePanel.open()` succeeds so the popup dismisses itself once coaching is underway.

## Change

Single 2-line addition in `src/popup/Popup.tsx`:

\`\`\`diff
  if (chrome.sidePanel && tab.windowId !== undefined) {
    try {
      await chrome.sidePanel.open({ windowId: tab.windowId })
      console.log('✅ [Popup] Side panel opened successfully')
+     // Close popup so agent doesn't re-click Start Coaching
+     window.close()
    } catch (sidePanelError) {
      console.warn('⚠️ [Popup] Could not open side panel:', sidePanelError)
    }
  }
\`\`\`

## Edge cases preserved

- ✅ Sidebar fails to open → popup stays open (user needs to see/retry)
- ✅ Validation fails (no tab, wrong URL) → popup stays open with alert
- ✅ Exception during start → popup stays open with alert
- ✅ Double-click protection (\`disabled={isStarting}\`) still in place

## Files changed

| File | Change |
|------|--------|
| \`src/popup/Popup.tsx\` | Added \`window.close()\` after sidebar opens |
| \`package.json\` | Version 2.2.6 → 2.2.7 |
| \`vite.config.ts\` | Version 2.2.6 → 2.2.7 |
| \`src/background/index.ts\` | Telemetry version 2.2.6 → 2.2.7 |

## Test plan

- [x] **Happy path:** On CallTools tab → Start Coaching → sidebar opens + popup closes
- [x] **Wrong URL:** On non-CallTools tab → Start Coaching → popup stays open with alert
- [x] **Rapid click:** Button \`disabled\` prevents second click; popup closes after sidebar
- [x] **Reopen popup:** Click icon again after coaching started → popup shows current state

## Rollback

Git revert. Pure frontend change — no CDK/backend deploy needed.