### PR TITLE
feat(history): local call history storage with IndexedDB + sidebar viewer (v2.2.8)

### DIFF
--- a/doc/eod/2026-04-20-call-coach-EOD.md
+++ b/doc/eod/2026-04-20-call-coach-EOD.md
@@ -1,0 +1,142 @@
+# Call Coach Chrome Extension — End of Day Report
+
+**Date:** April 20, 2026
+**Developer:** Kayser B
+**Project:** DevAssist-Call-Coach
+
+---
+
+## Session Overview
+
+**Focus:** Popup UX fix, local call history storage + viewer, weekly billing request, prior EOD reports.
+
+**Outcome:** 5 commits landed today. 2 PRs shipped and merged (#69), 1 feature branch in review (`feat/local-call-history`). Versions bumped 2.2.6 → 2.2.7 → 2.2.8.
+
+---
+
+## Commits Today
+
+| Commit | Message |
+|--------|---------|
+| `28494f4` | feat(request): add weekly billing and usage request for April 13-19, 2026 |
+| `a8ebf19` | fix(popup): close popup after sidebar opens (v2.2.7) |
+| `10c1fab` | fix(popup): close popup after sidebar opens (v2.2.7) (#69) |
+| `090674c` | chore: bump version to 2.2.8 and implement call history feature |
+| `6b532f0` | feat(history): capture destination, entities, intelligence; add download buttons |
+
+---
+
+## Accomplishments
+
+### 1. ✅ PR #69 — Close popup after sidebar opens (v2.2.7)
+
+**Commits:** `a8ebf19` → merged as `10c1fab`
+
+**Problem:** When an agent clicked "Start Coaching", the sidebar opened but the popup stayed visible with the Start Coaching button still there. Some agents clicked it again, triggering duplicate coaching starts.
+
+**Fix:** Added `window.close()` after `chrome.sidePanel.open()` succeeds so the popup dismisses itself once coaching is underway.
+
+**Files changed:**
+- `src/popup/Popup.tsx` — +2 lines
+- `package.json`, `vite.config.ts`, `src/background/index.ts` — version bump to 2.2.7
+
+**Edge cases preserved:**
+- Sidebar fails to open → popup stays open (user needs to see/retry)
+- Validation fails (no tab, wrong URL) → popup stays open with alert
+- Exception during start → popup stays open with alert
+- Double-click protection (`disabled={isStarting}`) still in place
+
+---
+
+### 2. ✅ EOD reports + weekly billing request doc
+
+**Commit:** `28494f4`
+
+Added three documentation files:
+- `doc/eod/2026-04-15-call-coach-EOD.md` — backfill EOD for Wed (trim window, identity framing, hostile detection)
+- `doc/eod/2026-04-17-call-coach-EOD.md` — backfill EOD for Fri (OpenAI failover shipped as PR #65)
+- `doc/requests/2026-04-20-weekly-billing-usage-request.md` — request for Cobb for weekly cost & usage breakdown (April 13–19) at 12-15 active users
+
+---
+
+### 3. 🔨 Local Call History Feature (v2.2.8) — `feat/local-call-history` branch
+
+Two commits on the feature branch, pushed to origin, awaiting PR.
+
+#### Commit `090674c` — Initial implementation
+
+- **Data layer:** `src/utils/history-store.ts` — IndexedDB wrapper with `saveTranscript`, `listTranscripts`, `getTranscript`, `pruneOldTranscripts`, `deleteTranscript`, `countTranscripts`
+- **Background hooks:** On `CALL_ENDED` (port-based, runtime-message, webhook paths), snapshot transcript and save to IndexedDB
+- **Call start tracking:** `currentCallStartedAt` module variable set on `CALL_STARTED` to record duration
+- **UI — History tab:** `src/components/HistoryTab.tsx` — list view grouped by day with refresh button and empty state
+- **UI — Transcript detail:** `src/components/TranscriptDetail.tsx` — chat-bubble style transcript with back navigation
+- **SidePanel integration:** Added Live / History toggle at top, conditional rendering based on view mode
+- **Retention:** Auto-prune transcripts older than 90 days on extension startup
+- **Per-agent scoping:** Records keyed by `conversationId`, filtered by `agentEmail` in the list view
+- **Plan doc:** `doc/plans/2026-04-20-local-call-history-storage.md`
+
+#### Commit `6b532f0` — Capture more data + download buttons
+
+**Destination capture:**
+- Hooked `message.destination` from CALL_STARTED (port + runtime handlers)
+- Added `currentCallDestination` module variable alongside `currentCallStartedAt`
+- Captures destination from content script DOM scrape OR webhook `payload.destination`
+
+**Intelligence + entities in records:**
+- Stashed `latestIntelligence` and `latestEntities` on `ExtensionState` during `INTELLIGENCE_UPDATE`
+- Included in `CallHistoryRecord` via `saveTranscript()` call
+- Cleared on each new `CALL_STARTED` so records don't inherit stale data
+- Extended `CallHistoryRecord` schema with `intelligence` and `entities` fields
+
+**Smarter labels in list:**
+- Label priority: phone number → customer name → business name → date/time
+- Removed "Unknown number" text entirely
+- Secondary row shows outcome (derived from top intent) + sentiment (color-coded: green/red/gray)
+
+**Transcript detail enhancements:**
+- Intelligence panel at top showing: Customer Sentiment, Confidence, Business, Website Status, Phone, Email, Website, Location, Dates, People, Customer Intent, Discussion Topics, Summary
+- TXT download button — matches live export format (includes intelligence dashboard + full transcript)
+- JSON download button — full `CallHistoryRecord` for archival/import
+
+---
+
+### 4. ✅ Cost audit
+
+Ran comprehensive cost-spike audit on the codebase. Findings:
+
+- ✅ No DynamoDB Scan operations anywhere (the original $500 culprit)
+- ✅ TTL on all DynamoDB tables (2h connections, 24h events)
+- ✅ Lambda timeouts properly set
+- ✅ PostgreSQL connection pool bounded (max: 2)
+- ✅ WebSocket reconnect with exponential backoff + 5-attempt max
+- ✅ CloudWatch log retention at 1 week
+- 🟡 No client-side throttle on `getIntelligence` — flagged as future mitigation (UI has 4 layers of button protection so risk is low; only real attack vector is external scripting)
+
+No immediate action taken. Fix queued for future session.
+
+---
+
+## PRs
+
+| PR | Title | Version | Status |
+|----|-------|---------|--------|
+| [#69](https://github.com/Simple-biz/simple-biz-call-coach/pull/69) | fix(popup): close popup after sidebar opens | 2.2.7 | Merged |
+| [#71](https://github.com/Simple-biz/simple-biz-call-coach/pull/71) | feat(history): local call history storage with IndexedDB + sidebar viewer | 2.2.8 | Open |
+
+---
+
+## Files Changed Today
+
+| File | Commits |
+|------|---------|
+| `src/popup/Popup.tsx` | `a8ebf19` |
+| `src/utils/history-store.ts` | `090674c` (new) |
+| `src/components/HistoryTab.tsx` | `090674c` (new), `6b532f0` |
+| `src/components/TranscriptDetail.tsx` | `090674c` (new), `6b532f0` |
+| `src/sidepanel/SidePanel.tsx` | `090674c` |
+| `src/background/index.ts` | `a8ebf19`, `090674c`, `6b532f0` |
+| `doc/plans/2026-04-20-local-call-history-storage.md` | `090674c` (new) |
+| `doc/eod/2026-04-15-call-coach-EOD.md` | `28494f4` (new) |
+| `doc/eod/2026-04-17-call-coach-EOD.md` | `28494f4` (new) |
+| `doc/requests/2026-04-20-weekly-billing-usage-request.md` | `28494f4` (new) |
+| `package.json`, `vite.config.ts` | Version bumps to 2.2.7, then 2.2.8 |

--- a/doc/plans/2026-04-20-local-call-history-storage.md
+++ b/doc/plans/2026-04-20-local-call-history-storage.md
@@ -1,0 +1,238 @@
+# Plan: Save Transcripts Locally + History Viewer
+
+**Date:** April 20, 2026
+**Author:** Kayser B
+**Status:** Draft — pending review
+**Target version:** v2.2.8
+
+---
+
+## Goal
+
+1. Save each completed call's **transcript** locally on the agent's machine (IndexedDB)
+2. Add a **"History" button/tab in the sidebar** so the agent can see and review past call transcripts
+
+**Non-goals:**
+- No AI tips or intelligence saved (transcripts only)
+- No cloud changes
+- No export/search/star/edit features yet — just view
+
+---
+
+## Two parts to this
+
+### Part 1 — Data layer (save transcripts locally)
+
+When a call ends, snapshot the transcript to IndexedDB.
+
+### Part 2 — UI (view past transcripts)
+
+Add a "History" tab to the sidebar that lists past calls and shows the transcript when one is selected.
+
+---
+
+## Data Layer
+
+### What gets saved
+
+One record per completed call:
+
+```typescript
+{
+  conversationId: string;
+  agentEmail: string;
+  startedAt: number;       // epoch ms
+  endedAt: number;         // epoch ms
+  destination?: string;    // phone dialed (from CALL_ENDED webhook, if available)
+  transcript: Array<{
+    speaker: 'agent' | 'caller';
+    text: string;
+    timestamp: number;
+  }>;
+}
+```
+
+Only `isFinal: true` transcript entries are kept (skip interim chunks).
+
+### Storage
+
+- **IndexedDB** database: `call-coach-history`
+- **Object store:** `transcripts`
+- **Key:** `conversationId`
+- **Indices:** `agentEmail`, `endedAt`
+- **Retention:** auto-prune >90 days old, on extension startup
+
+### When it saves
+
+On `CALL_ENDED`, the background service worker snapshots `extensionState.transcriptions`, assembles the record, and fires `saveTranscript(record)` — fire-and-forget.
+
+If save fails, log and continue. Never block normal cleanup.
+
+---
+
+## UI Layer
+
+### Where it lives
+
+**Inside the sidebar.** Agents already use the sidebar for live coaching — natural extension.
+
+### How it looks
+
+**Top-of-sidebar view toggle:**
+
+```
+┌─────────────────────────────────┐
+│  [ Live ]   [ History ]         │   ← toggle at top
+├─────────────────────────────────┤
+│                                  │
+│  (current live view OR           │
+│   history list, depending        │
+│   on toggle)                     │
+│                                  │
+└─────────────────────────────────┘
+```
+
+When `Live` is selected (default): existing coaching UI — unchanged.
+
+When `History` is selected: new list view showing past calls.
+
+### History list view
+
+```
+┌─────────────────────────────────┐
+│  [ Live ]   [ History* ]        │
+├─────────────────────────────────┤
+│  Today                           │
+│  ─────────────────               │
+│  📞 +1 (555) 234-1234   3m 22s  │
+│  11:42 AM                        │
+│                                  │
+│  📞 +1 (555) 890-7654   1m 05s  │
+│  10:18 AM                        │
+│                                  │
+│  Yesterday                       │
+│  ─────────────────               │
+│  📞 +1 (555) 444-9999   5m 48s  │
+│  4:32 PM                         │
+│                                  │
+│  ...                             │
+└─────────────────────────────────┘
+```
+
+Each row shows:
+- Phone number dialed (if captured)
+- Duration
+- Time of day
+
+Grouped by day (Today / Yesterday / MMM DD).
+
+### Transcript detail view
+
+Tap a row → expand/drill into full transcript:
+
+```
+┌─────────────────────────────────┐
+│  ← Back to History               │
+├─────────────────────────────────┤
+│  +1 (555) 234-1234               │
+│  Today at 11:42 AM · 3m 22s     │
+├─────────────────────────────────┤
+│                                  │
+│  AGENT: Hi, is this John?        │
+│  CALLER: Yeah, who's this?       │
+│  AGENT: Bob and I are local web… │
+│  CALLER: Oh, we already have…    │
+│  ...                             │
+│                                  │
+└─────────────────────────────────┘
+```
+
+Scrollable. Plain text. No fancy formatting.
+
+### Empty states
+
+- **No calls yet:** `"No calls saved yet. Your completed calls will appear here."`
+- **IndexedDB unavailable:** `"History unavailable — please reload the extension."`
+
+---
+
+## Files
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `src/utils/history-store.ts` | IndexedDB wrapper (`saveTranscript`, `listTranscripts`, `getTranscript`, `pruneOldTranscripts`) |
+| `src/sidepanel/components/HistoryTab.tsx` | List view of past calls |
+| `src/sidepanel/components/TranscriptDetail.tsx` | Full transcript display |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/background/index.ts` | On `CALL_ENDED`, save transcript + run prune on startup |
+| `src/sidepanel/SidePanel.tsx` | Add Live / History toggle at top; conditionally render HistoryTab |
+| `package.json`, `vite.config.ts`, `src/background/index.ts` | Version bump 2.2.7 → 2.2.8 |
+
+---
+
+## Effort
+
+| Task | Time |
+|------|:----:|
+| `history-store.ts` (IndexedDB wrapper) | 2 hrs |
+| Hook into `CALL_ENDED` + prune logic | 1 hr |
+| `HistoryTab` list component | 2 hrs |
+| `TranscriptDetail` view + back navigation | 1 hr |
+| Live/History toggle in SidePanel | 1 hr |
+| Manual test + commit | 1 hr |
+| **Total** | **~8 hrs (1 day)** |
+
+---
+
+## Testing
+
+Manual:
+1. Build + reload extension
+2. Complete 2-3 real calls
+3. Open sidebar → click **History** toggle
+4. Verify list shows all completed calls with right dates/durations
+5. Click a call → verify full transcript displays
+6. Click back → verify returns to list
+7. DevTools → IndexedDB → confirm records persist across browser restart
+
+---
+
+## Cost Impact
+
+**Zero.**
+
+- IndexedDB lives on the agent's browser — no AWS, no APIs, no network
+- No new Lambda invocations
+- No new database bills
+- Agent disk usage: ~30-50 KB per call, 90-day auto-prune keeps total well under 100 MB
+
+---
+
+## Rollback
+
+Pure frontend, additive:
+
+```bash
+git revert <commit>
+npm run build
+# Reload extension
+```
+
+Stale IndexedDB records on agent machines are harmless — future versions can clear or migrate them.
+
+---
+
+## Summary
+
+- **Data:** 1 new utility file, 1 hook in background service worker
+- **UI:** 2 new components + a toggle in the existing sidebar
+- **~1 day of work**
+- **Zero cloud cost**
+
+Ship as one PR for a cohesive feature (data + viewer together), or split into two PRs (data-only first, UI second) — your call.

--- a/docker/sandbox/package-lock.json
+++ b/docker/sandbox/package-lock.json
@@ -1,0 +1,430 @@
+{
+  "name": "devassist-sandbox",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "devassist-sandbox",
+      "version": "1.0.0",
+      "dependencies": {
+        "uuid": "^9.0.1",
+        "ws": "^8.16.0"
+      },
+      "devDependencies": {
+        "nodemon": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devassist-call-coach",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -119,8 +119,9 @@ let keepAliveInterval: number | null = null
 // LOCAL CALL HISTORY — save transcripts to IndexedDB on CALL_ENDED
 // ============================================================================
 
-// Track call start time so we can record duration when the call ends
+// Track call start time + destination so we can attach them to the history record on hang-up
 let currentCallStartedAt: number | null = null;
+let currentCallDestination: string | null = null;
 
 async function saveCurrentCallToHistory(): Promise<void> {
   try {
@@ -153,7 +154,7 @@ async function saveCurrentCallToHistory(): Promise<void> {
       agentEmail: extensionState.userEmail || 'unknown',
       startedAt,
       endedAt,
-      destination: undefined, // populated from webhook payload in calling handler if available
+      destination: currentCallDestination ?? undefined,
       transcript: finalEntries,
       intelligence: extensionState.latestIntelligence ?? null,
       entities: extensionState.latestEntities ?? null,
@@ -294,6 +295,15 @@ chrome.runtime.onConnect.addListener(port => {
       if (message.type === 'CALL_STARTED') {
         console.log('📞 [Background] Call STARTED detected (via port)')
 
+        // Track call start time + clear previous call's history fields
+        currentCallStartedAt = Date.now()
+        currentCallDestination = message.destination || null
+        extensionState.latestIntelligence = null
+        extensionState.latestEntities = null
+        if (currentCallDestination) {
+          console.log(`📱 [Background] Destination captured from CALL_STARTED: ${currentCallDestination}`)
+        }
+
         // ✅ CLEAR ALL PREVIOUS CALL DATA (fresh start for new call)
         console.log('🧹 [Background] Clearing ALL data from previous call')
         extensionState.transcriptions = []
@@ -356,6 +366,7 @@ chrome.runtime.onConnect.addListener(port => {
         const digits = message.destination?.replace(/\D/g, '') || ''
         if (digits.length >= 10) {
           expectedDestination = digits
+          currentCallDestination = message.destination || digits
           console.log(`📱 [Background] Expected destination set: ${digits}`)
         }
       }
@@ -599,11 +610,14 @@ async function processMessage(message: any, sender: any) {
         return
       }
 
-      // Track call start time for local history record
+      // Track call start time + clear previous call's history fields
       currentCallStartedAt = Date.now()
-      // Clear stashed intelligence from previous call
+      currentCallDestination = message.destination || null
       extensionState.latestIntelligence = null
       extensionState.latestEntities = null
+      if (currentCallDestination) {
+        console.log(`📱 [Background] Destination captured from CALL_STARTED: ${currentCallDestination}`)
+      }
 
       // ✅ CLEAR ALL PREVIOUS CALL DATA (fresh start for new call)
       console.log('🧹 [Background] Clearing ALL data from previous call')
@@ -1184,6 +1198,11 @@ async function connectAIBackend() {
 
     // Webhook STATUS_UPDATE listener (call start/end from CallTools resthook)
     awsWebSocketService.setStatusUpdateListener(async (payload) => {
+      // Capture destination for history whenever we see it
+      if (payload.destination) {
+        currentCallDestination = payload.destination
+      }
+
       if (payload.event === 'CALL_STARTED') {
         // Already on a call — enrich with callId if within 15s
         if (extensionState.isOnCall) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -25,6 +25,7 @@ console.log('🚀 [Background] Service worker started')
 // Import AWS WebSocket service for real-time coaching
 // Import AI Backend Service (Legacy Socket.io for Elastic Beanstalk fallback)
 import { awsWebSocketService } from '@/services/aws-websocket.service'
+import { saveTranscript, pruneOldTranscripts } from '@/utils/history-store'
 
 // ============================================================================
 // TYPE DEFINITIONS
@@ -64,6 +65,8 @@ interface ExtensionState {
   callToolsCallId?: string | null
   callDetectionSource?: 'webhook' | 'dom' | null
   coachingPending?: boolean
+  latestIntelligence?: any | null
+  latestEntities?: any | null
 }
 
 // Webhook destination matching — content script reports the number being dialed
@@ -111,6 +114,59 @@ chrome.storage.local.get(['coachingPending', 'userEmail', 'isAuthenticated']).th
 
 // Keep-alive mechanism
 let keepAliveInterval: number | null = null
+
+// ============================================================================
+// LOCAL CALL HISTORY — save transcripts to IndexedDB on CALL_ENDED
+// ============================================================================
+
+// Track call start time so we can record duration when the call ends
+let currentCallStartedAt: number | null = null;
+
+async function saveCurrentCallToHistory(): Promise<void> {
+  try {
+    const transcripts = extensionState.transcriptions || [];
+    const finalEntries = transcripts
+      .filter((t: TranscriptionEntry) => t.isFinal && t.transcript)
+      .map((t: TranscriptionEntry) => ({
+        // offscreen emits 'agent' | 'caller' — normalize 'caller' → 'customer'
+        speaker: (t.speaker === 'agent' ? 'agent' : 'customer') as 'agent' | 'customer',
+        text: t.transcript,
+        timestamp: t.timestamp,
+      }));
+
+    if (finalEntries.length === 0) {
+      console.log('[History] No final transcripts to save — skipping');
+      return;
+    }
+
+    const conversationId = extensionState.conversationId;
+    if (!conversationId) {
+      console.log('[History] No conversationId — skipping save');
+      return;
+    }
+
+    const endedAt = Date.now();
+    const startedAt = currentCallStartedAt ?? extensionState.startTime ?? endedAt;
+
+    await saveTranscript({
+      conversationId,
+      agentEmail: extensionState.userEmail || 'unknown',
+      startedAt,
+      endedAt,
+      destination: undefined, // populated from webhook payload in calling handler if available
+      transcript: finalEntries,
+      intelligence: extensionState.latestIntelligence ?? null,
+      entities: extensionState.latestEntities ?? null,
+    });
+  } catch (err) {
+    console.warn('[History] saveCurrentCallToHistory failed:', err);
+  }
+}
+
+// Prune old transcripts on startup (fire-and-forget)
+pruneOldTranscripts().catch(err =>
+  console.warn('[History] startup prune failed:', err)
+);
 
 // ============================================================================
 // AUTO-ANALYSIS LOOP — intelligence updates only (tips via streaming on click)
@@ -285,10 +341,15 @@ chrome.runtime.onConnect.addListener(port => {
 
       if (message.type === 'CALL_ENDED') {
         console.log('📞 [Background] Call ENDED detected (via port)')
+
+        // Save transcript to local history (fire-and-forget)
+        saveCurrentCallToHistory()
+
         await updateExtensionState({ isOnCall: false })
         await handleCallEnd(tabId)
         stopAutoAnalysisLoop();
         stopKeepAlive()
+        currentCallStartedAt = null
       }
 
       if (message.type === 'DESTINATION_NUMBER_DETECTED') {
@@ -538,6 +599,12 @@ async function processMessage(message: any, sender: any) {
         return
       }
 
+      // Track call start time for local history record
+      currentCallStartedAt = Date.now()
+      // Clear stashed intelligence from previous call
+      extensionState.latestIntelligence = null
+      extensionState.latestEntities = null
+
       // ✅ CLEAR ALL PREVIOUS CALL DATA (fresh start for new call)
       console.log('🧹 [Background] Clearing ALL data from previous call')
       extensionState.transcriptions = []
@@ -608,6 +675,9 @@ async function processMessage(message: any, sender: any) {
     case 'CALL_ENDED':
       console.log('📞 [Background] Call ENDED detected - retaining call data for review')
 
+      // Save transcript to local history (fire-and-forget)
+      saveCurrentCallToHistory()
+
       // ✅ UPDATE STATE FIRST
       await updateExtensionState({
         isOnCall: false,
@@ -616,6 +686,7 @@ async function processMessage(message: any, sender: any) {
       // Then handle cleanup (but DON'T clear transcriptions/tips - keep for review)
       await handleCallEnd(sender.tab?.id)
       stopKeepAlive()
+      currentCallStartedAt = null
 
       // Notify UI that call ended (but data should remain visible)
       broadcastToUI({
@@ -1091,6 +1162,11 @@ async function connectAIBackend() {
 
     awsWebSocketService.setIntelligenceListener((payload) => {
       console.log('🧠 [Background] Intelligence update received')
+      // Stash latest snapshot so we can attach it to the call history record on hang-up
+      if (payload) {
+        extensionState.latestIntelligence = (payload as any).intelligence ?? null
+        extensionState.latestEntities = (payload as any).entities ?? null
+      }
       broadcastToUI({
         type: 'INTELLIGENCE_UPDATE',
         payload,
@@ -1172,6 +1248,10 @@ async function connectAIBackend() {
         }
 
         console.log('📞 [Background] Webhook detected CALL_ENDED — ending call')
+
+        // Save transcript to local history (fire-and-forget)
+        saveCurrentCallToHistory()
+
         updateExtensionState({
           isOnCall: false,
           callDetectionSource: null,
@@ -1180,6 +1260,7 @@ async function connectAIBackend() {
 
         handleCallEnd(extensionState.tabId || undefined)
         stopKeepAlive()
+        currentCallStartedAt = null
 
         broadcastToUI({
           type: 'CALL_ENDED_RETAIN_DATA',
@@ -1203,7 +1284,7 @@ async function connectAIBackend() {
       {
         source: 'devassist-call-coach',
         tabId: extensionState.tabId,
-        version: '2.2.7',
+        version: '2.2.8',
       }
     )
 

--- a/src/components/HistoryTab.tsx
+++ b/src/components/HistoryTab.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { Phone, ChevronRight, RefreshCw } from 'lucide-react';
+import { listTranscripts, type CallHistoryRecord } from '@/utils/history-store';
+import { TranscriptDetail } from './TranscriptDetail';
+
+interface HistoryTabProps {
+  agentEmail?: string | null;
+}
+
+export function HistoryTab({ agentEmail }: HistoryTabProps) {
+  const [calls, setCalls] = useState<CallHistoryRecord[]>([]);
+  const [selected, setSelected] = useState<CallHistoryRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadCalls = async () => {
+    setLoading(true);
+    try {
+      const results = await listTranscripts({
+        agentEmail: agentEmail || undefined,
+        limit: 200,
+      });
+      setCalls(results);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCalls();
+  }, [agentEmail]);
+
+  if (selected) {
+    return (
+      <TranscriptDetail
+        record={selected}
+        onBack={() => setSelected(null)}
+      />
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64 text-gray-500">
+        <RefreshCw className="w-5 h-5 animate-spin mr-2" />
+        Loading history...
+      </div>
+    );
+  }
+
+  if (calls.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-center px-8 text-gray-500">
+        <Phone className="w-12 h-12 mb-3 opacity-40" />
+        <p className="text-sm">No calls saved yet.</p>
+        <p className="text-xs mt-1">Your completed calls will appear here.</p>
+      </div>
+    );
+  }
+
+  const grouped = groupByDay(calls);
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          Call History
+        </h2>
+        <button
+          onClick={loadCalls}
+          className="p-1 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+          title="Refresh"
+        >
+          <RefreshCw className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="flex-1">
+        {grouped.map(({ label, items }) => (
+          <div key={label}>
+            <div className="sticky top-0 px-4 py-2 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 uppercase">
+              {label}
+            </div>
+            {items.map(call => (
+              <button
+                key={call.conversationId}
+                onClick={() => setSelected(call)}
+                className="w-full flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800 text-left transition-colors"
+              >
+                <Phone className="w-4 h-4 text-gray-400 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    {call.destination || 'Unknown number'}
+                  </div>
+                  <div className="text-xs text-gray-500 flex items-center gap-2 mt-0.5">
+                    <span>{formatTime(call.endedAt)}</span>
+                    <span>·</span>
+                    <span>{formatDuration(call.startedAt, call.endedAt)}</span>
+                    <span>·</span>
+                    <span>{call.transcript.length} lines</span>
+                  </div>
+                </div>
+                <ChevronRight className="w-4 h-4 text-gray-400 shrink-0" />
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ──
+
+function groupByDay(calls: CallHistoryRecord[]) {
+  const groups = new Map<string, CallHistoryRecord[]>();
+  for (const c of calls) {
+    const label = dayLabel(c.endedAt);
+    const bucket = groups.get(label) ?? [];
+    bucket.push(c);
+    groups.set(label, bucket);
+  }
+  return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
+}
+
+function dayLabel(ts: number): string {
+  const d = new Date(ts);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  const callDay = new Date(d);
+  callDay.setHours(0, 0, 0, 0);
+
+  if (callDay.getTime() === today.getTime()) return 'Today';
+  if (callDay.getTime() === yesterday.getTime()) return 'Yesterday';
+
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: d.getFullYear() === today.getFullYear() ? undefined : 'numeric',
+  });
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatDuration(startedAt: number, endedAt: number): string {
+  const seconds = Math.max(0, Math.round((endedAt - startedAt) / 1000));
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m === 0) return `${s}s`;
+  return `${m}m ${s.toString().padStart(2, '0')}s`;
+}

--- a/src/components/HistoryTab.tsx
+++ b/src/components/HistoryTab.tsx
@@ -80,28 +80,48 @@ export function HistoryTab({ agentEmail }: HistoryTabProps) {
             <div className="sticky top-0 px-4 py-2 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 uppercase">
               {label}
             </div>
-            {items.map(call => (
-              <button
-                key={call.conversationId}
-                onClick={() => setSelected(call)}
-                className="w-full flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800 text-left transition-colors"
-              >
-                <Phone className="w-4 h-4 text-gray-400 shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                    {call.destination || 'Unknown number'}
+            {items.map(call => {
+              const label = getCallLabel(call);
+              const outcome = getOutcomeLabel(call);
+              const sentiment = call.intelligence?.sentiment?.label;
+
+              return (
+                <button
+                  key={call.conversationId}
+                  onClick={() => setSelected(call)}
+                  className="w-full flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800 text-left transition-colors"
+                >
+                  <Phone className="w-4 h-4 text-gray-400 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {label}
+                    </div>
+                    {(outcome || sentiment) && (
+                      <div className="flex items-center gap-2 mt-0.5">
+                        {outcome && (
+                          <span className="text-xs font-medium text-[#1B1F6B] dark:text-blue-300">
+                            {outcome}
+                          </span>
+                        )}
+                        {sentiment && (
+                          <span className={`text-xs font-medium ${getSentimentClass(sentiment)}`}>
+                            · {capitalize(sentiment)}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                    <div className="text-xs text-gray-500 flex items-center gap-2 mt-0.5">
+                      <span>{formatTime(call.endedAt)}</span>
+                      <span>·</span>
+                      <span>{formatDuration(call.startedAt, call.endedAt)}</span>
+                      <span>·</span>
+                      <span>{call.transcript.length} lines</span>
+                    </div>
                   </div>
-                  <div className="text-xs text-gray-500 flex items-center gap-2 mt-0.5">
-                    <span>{formatTime(call.endedAt)}</span>
-                    <span>·</span>
-                    <span>{formatDuration(call.startedAt, call.endedAt)}</span>
-                    <span>·</span>
-                    <span>{call.transcript.length} lines</span>
-                  </div>
-                </div>
-                <ChevronRight className="w-4 h-4 text-gray-400 shrink-0" />
-              </button>
-            ))}
+                  <ChevronRight className="w-4 h-4 text-gray-400 shrink-0" />
+                </button>
+              );
+            })}
           </div>
         ))}
       </div>
@@ -155,4 +175,67 @@ function formatDuration(startedAt: number, endedAt: number): string {
   const s = seconds % 60;
   if (m === 0) return `${s}s`;
   return `${m}m ${s.toString().padStart(2, '0')}s`;
+}
+
+// ── Call labeling helpers ──
+
+function getCallLabel(call: CallHistoryRecord): string {
+  // Priority: phone > customer name > business > date/time fallback
+  if (call.destination) return call.destination;
+
+  const person = call.entities?.people?.[0];
+  if (person) return person;
+
+  const business = call.entities?.businessNames?.[0];
+  if (business) return business;
+
+  // Final fallback: date/time
+  const d = new Date(call.endedAt);
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Derive a short outcome label from intents + website status.
+ * Returns null if there's nothing meaningful to show.
+ */
+function getOutcomeLabel(call: CallHistoryRecord): string | null {
+  const intents = call.intelligence?.intents || [];
+  if (intents.length === 0) return null;
+
+  // Sort by confidence, pick top
+  const top = [...intents].sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0];
+  if (!top) return null;
+
+  const map: Record<string, string> = {
+    request_callback: 'Callback agreed',
+    not_interested: 'Not interested',
+    interested: 'Interested',
+    pricing_inquiry: 'Asked pricing',
+    objection: 'Objection',
+    purchase_intent: 'Buying signal',
+    information_seeking: 'Info gathering',
+  };
+
+  return map[top.intent] || capitalize(top.intent.replace(/_/g, ' '));
+}
+
+function getSentimentClass(sentiment: string): string {
+  switch (sentiment.toLowerCase()) {
+    case 'positive':
+      return 'text-green-600 dark:text-green-400';
+    case 'negative':
+      return 'text-red-600 dark:text-red-400';
+    default:
+      return 'text-gray-500';
+  }
+}
+
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/src/components/TranscriptDetail.tsx
+++ b/src/components/TranscriptDetail.tsx
@@ -1,0 +1,163 @@
+import { ArrowLeft, Phone } from 'lucide-react';
+import type { CallHistoryRecord, HistoryIntelligence, HistoryEntities } from '@/utils/history-store';
+
+interface TranscriptDetailProps {
+  record: CallHistoryRecord;
+  onBack: () => void;
+}
+
+export function TranscriptDetail({ record, onBack }: TranscriptDetailProps) {
+  const endedDate = new Date(record.endedAt);
+  const durationSec = Math.max(0, Math.round((record.endedAt - record.startedAt) / 1000));
+  const m = Math.floor(durationSec / 60);
+  const s = durationSec % 60;
+  const durationStr = m === 0 ? `${s}s` : `${m}m ${s.toString().padStart(2, '0')}s`;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 sticky top-0 z-10">
+        <button
+          onClick={onBack}
+          className="p-1 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+          aria-label="Back to history"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <Phone className="w-4 h-4 text-gray-400" />
+            {record.destination || 'Unknown number'}
+          </div>
+          <div className="text-xs text-gray-500 mt-0.5">
+            {endedDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+            {' · '}
+            {endedDate.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+            {' · '}
+            {durationStr}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <IntelligencePanel intelligence={record.intelligence} entities={record.entities} />
+
+        <div className="px-4 py-4 space-y-3">
+          {record.transcript.length === 0 ? (
+            <div className="text-center text-sm text-gray-500 py-8">
+              No transcript content.
+            </div>
+          ) : (
+            record.transcript.map((entry, idx) => (
+              <div
+                key={idx}
+                className={`flex ${entry.speaker === 'agent' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[85%] rounded-lg px-3 py-2 ${
+                    entry.speaker === 'agent'
+                      ? 'bg-blue-50 text-blue-900 dark:bg-blue-900/30 dark:text-blue-100'
+                      : 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                  }`}
+                >
+                  <div className="text-[10px] uppercase font-semibold opacity-60 mb-0.5">
+                    {entry.speaker === 'agent' ? 'Agent' : 'Customer'}
+                  </div>
+                  <div className="text-sm whitespace-pre-wrap">{entry.text}</div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Intelligence summary (sentiment, entities, intents, topics) ──
+
+function IntelligencePanel({
+  intelligence,
+  entities,
+}: {
+  intelligence?: HistoryIntelligence | null;
+  entities?: HistoryEntities | null;
+}) {
+  const sentimentLabel = intelligence?.sentiment?.label ?? 'neutral';
+  const sentimentScore = intelligence?.sentiment?.score;
+
+  const businessNames = entities?.businessNames ?? [];
+  const websiteStatus = entities?.websiteStatus ?? 'unknown';
+  const phones = entities?.contactInfo?.phoneNumbers ?? [];
+  const emails = entities?.contactInfo?.emails ?? [];
+  const urls = entities?.contactInfo?.urls ?? [];
+  const locations = entities?.locations ?? [];
+  const dates = entities?.dates ?? [];
+  const people = entities?.people ?? [];
+  const intents = intelligence?.intents ?? [];
+  const topics = intelligence?.topics ?? [];
+
+  // Hide the panel entirely if there's no intelligence data at all
+  const hasAny =
+    intelligence ||
+    businessNames.length ||
+    phones.length ||
+    emails.length ||
+    urls.length ||
+    locations.length ||
+    dates.length ||
+    people.length ||
+    intents.length ||
+    topics.length;
+
+  if (!hasAny) return null;
+
+  return (
+    <div className="px-4 py-3 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
+      <div className="text-xs font-semibold uppercase text-gray-500 mb-2">
+        Conversation Intelligence
+      </div>
+
+      <Row label="Customer Sentiment" value={sentimentLabel} />
+      {typeof sentimentScore === 'number' && (
+        <Row label="Confidence" value={sentimentScore.toFixed(2)} />
+      )}
+      <Row label="Business" value={listOrDash(businessNames)} />
+      <Row label="Website Status" value={formatWebsiteStatus(websiteStatus)} />
+      <Row label="Phone" value={listOrDash(phones)} />
+      <Row label="Email" value={listOrDash(emails)} />
+      <Row label="Website" value={listOrDash(urls)} />
+      <Row label="Location" value={listOrDash(locations)} />
+      <Row label="Dates" value={listOrDash(dates)} />
+      <Row label="People" value={listOrDash(people)} />
+      <Row label="Customer Intent" value={listOrDash(intents.map(i => i.intent))} />
+      <Row label="Discussion Topics" value={listOrDash(topics.map(t => t.topic))} />
+
+      {intelligence?.summary && (
+        <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+          <div className="text-[10px] uppercase font-semibold text-gray-500 mb-1">Summary</div>
+          <div className="text-sm text-gray-800 dark:text-gray-200">{intelligence.summary}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-3 py-1 text-sm">
+      <span className="text-gray-500 shrink-0">{label}</span>
+      <span className="text-gray-900 dark:text-gray-100 text-right break-words">{value}</span>
+    </div>
+  );
+}
+
+function listOrDash(arr: string[]): string {
+  if (!arr || arr.length === 0) return '--';
+  return arr.join(', ');
+}
+
+function formatWebsiteStatus(status: 'has_website' | 'no_website' | 'unknown' | undefined): string {
+  if (status === 'has_website') return 'Has website';
+  if (status === 'no_website') return 'No website';
+  return '--';
+}

--- a/src/components/TranscriptDetail.tsx
+++ b/src/components/TranscriptDetail.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Phone } from 'lucide-react';
+import { ArrowLeft, Phone, Download } from 'lucide-react';
 import type { CallHistoryRecord, HistoryIntelligence, HistoryEntities } from '@/utils/history-store';
 
 interface TranscriptDetailProps {
@@ -13,6 +13,13 @@ export function TranscriptDetail({ record, onBack }: TranscriptDetailProps) {
   const s = durationSec % 60;
   const durationStr = m === 0 ? `${s}s` : `${m}m ${s.toString().padStart(2, '0')}s`;
 
+  // Same priority cascade as history list: phone > customer name > business > date/time
+  const label =
+    record.destination ||
+    record.entities?.people?.[0] ||
+    record.entities?.businessNames?.[0] ||
+    endedDate.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 sticky top-0 z-10">
@@ -26,7 +33,7 @@ export function TranscriptDetail({ record, onBack }: TranscriptDetailProps) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
             <Phone className="w-4 h-4 text-gray-400" />
-            {record.destination || 'Unknown number'}
+            {label}
           </div>
           <div className="text-xs text-gray-500 mt-0.5">
             {endedDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
@@ -36,6 +43,22 @@ export function TranscriptDetail({ record, onBack }: TranscriptDetailProps) {
             {durationStr}
           </div>
         </div>
+        <button
+          onClick={() => downloadAsText(record, label)}
+          className="flex items-center gap-1 px-2 py-1 text-xs bg-[#1B1F6B] hover:bg-[#14174f] text-white rounded transition-colors"
+          title="Download as text"
+        >
+          <Download className="w-3 h-3" />
+          TXT
+        </button>
+        <button
+          onClick={() => downloadAsJSON(record, label)}
+          className="flex items-center gap-1 px-2 py-1 text-xs bg-[#1B1F6B] hover:bg-[#14174f] text-white rounded transition-colors"
+          title="Download as JSON"
+        >
+          <Download className="w-3 h-3" />
+          JSON
+        </button>
       </div>
 
       <div className="flex-1 overflow-y-auto">
@@ -160,4 +183,95 @@ function formatWebsiteStatus(status: 'has_website' | 'no_website' | 'unknown' | 
   if (status === 'has_website') return 'Has website';
   if (status === 'no_website') return 'No website';
   return '--';
+}
+
+// ── Downloads ──
+
+function safeFilename(s: string): string {
+  return s.replace(/[^a-z0-9\-_]/gi, '_').slice(0, 60);
+}
+
+function downloadBlob(content: string, filename: string, mime: string) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function downloadAsText(record: CallHistoryRecord, label: string) {
+  const endedDate = new Date(record.endedAt);
+  const durationSec = Math.max(0, Math.round((record.endedAt - record.startedAt) / 1000));
+  const m = Math.floor(durationSec / 60);
+  const s = durationSec % 60;
+  const durationStr = m === 0 ? `${s}s` : `${m}m ${s.toString().padStart(2, '0')}s`;
+
+  let text = `Call Transcript Export\n`;
+  text += `Call: ${label}\n`;
+  text += `Date: ${endedDate.toLocaleString()}\n`;
+  text += `Duration: ${durationStr}\n`;
+  text += `Total lines: ${record.transcript.length}\n`;
+
+  // Intelligence + entities dashboard
+  if (record.intelligence || record.entities) {
+    text += `\n${'='.repeat(50)}\n`;
+    text += `CONVERSATION INTELLIGENCE\n`;
+    text += `${'='.repeat(50)}\n\n`;
+
+    const s = record.intelligence?.sentiment;
+    if (s?.label) {
+      const scoreStr = typeof s.score === 'number' ? ` (${Math.round(s.score * 100)}% confidence)` : '';
+      text += `Sentiment: ${s.label}${scoreStr}\n`;
+    }
+
+    const e = record.entities;
+    if (e) {
+      if (e.businessNames?.length) text += `Business: ${e.businessNames.join(', ')}\n`;
+      if (e.websiteStatus && e.websiteStatus !== 'unknown') {
+        text += `Website Status: ${e.websiteStatus === 'has_website' ? 'Has Website' : 'No Website'}\n`;
+      }
+      if (e.contactInfo?.phoneNumbers?.length) text += `Phone: ${e.contactInfo.phoneNumbers.join(', ')}\n`;
+      if (e.contactInfo?.emails?.length) text += `Email: ${e.contactInfo.emails.join(', ')}\n`;
+      if (e.contactInfo?.urls?.length) text += `Website: ${e.contactInfo.urls.join(', ')}\n`;
+      if (e.locations?.length) text += `Location: ${e.locations.join(', ')}\n`;
+      if (e.dates?.length) text += `Dates: ${e.dates.join(', ')}\n`;
+      if (e.people?.length) text += `People: ${e.people.join(', ')}\n`;
+    }
+
+    if (record.intelligence?.intents?.length) {
+      text += `Intents: ${record.intelligence.intents.map(i => i.intent).join(', ')}\n`;
+    }
+    if (record.intelligence?.topics?.length) {
+      text += `Topics: ${record.intelligence.topics.map(t => t.topic).join(', ')}\n`;
+    }
+    if (record.intelligence?.summary) {
+      text += `\nSummary: ${record.intelligence.summary}\n`;
+    }
+  }
+
+  text += `\n${'='.repeat(50)}\n`;
+  text += `TRANSCRIPT\n`;
+  text += `${'='.repeat(50)}\n\n`;
+
+  record.transcript.forEach((entry) => {
+    const time = new Date(entry.timestamp).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    const speaker = entry.speaker === 'agent' ? 'Agent' : 'Customer';
+    text += `[${time}] ${speaker}: ${entry.text}\n\n`;
+  });
+
+  const dateStr = endedDate.toISOString().slice(0, 10);
+  downloadBlob(text, `call-${safeFilename(label)}-${dateStr}.txt`, 'text/plain');
+}
+
+function downloadAsJSON(record: CallHistoryRecord, label: string) {
+  const endedDate = new Date(record.endedAt);
+  const json = JSON.stringify(record, null, 2);
+  const dateStr = endedDate.toISOString().slice(0, 10);
+  downloadBlob(json, `call-${safeFilename(label)}-${dateStr}.json`, 'application/json');
 }

--- a/src/sidepanel/SidePanel.tsx
+++ b/src/sidepanel/SidePanel.tsx
@@ -11,6 +11,7 @@ import type { Transcription, CoachingTip, DeepgramStatus, ScriptOption } from "@
 import { ChatThread } from "@/components/ChatThread";
 import { IntelligenceDisplay } from "@/components/IntelligenceDisplay";
 import { SessionStats } from "@/components/SessionStats";
+import { HistoryTab } from "@/components/HistoryTab";
 import { pttDeepgramService, type PTTStatus } from "@/services/ptt-deepgram.service";
 import { useSettingsStore } from "@/stores/settings-store";
 
@@ -28,6 +29,10 @@ export default function SidePanel() {
   const [deepgramStatus, setDeepgramStatus] =
     useState<DeepgramStatus>("disconnected");
   const isLoadingScripts = useCallStore((s) => s.isGeneratingTip);
+
+  // View mode: Live coaching OR Call History
+  const [viewMode, setViewMode] = useState<'live' | 'history'>('live');
+  const [userEmail, setUserEmail] = useState<string | null>(null);
 
   // Sandbox mode: Customer input (text)
   const [customerMessage, setCustomerMessage] = useState('');
@@ -51,6 +56,11 @@ export default function SidePanel() {
     // Load persisted state on mount
     useCallStore.getState().loadFromStorage();
     console.log("📂 [SidePanel] Loading state from storage");
+
+    // Load user email for per-agent history filtering
+    chrome.storage.local.get(['userEmail'], (result: { userEmail?: string }) => {
+      if (result.userEmail) setUserEmail(result.userEmail);
+    });
 
     // Load Developer Mode setting from storage and sync with environment
     chrome.storage.local.get(['developerModeEnabled', 'deepgramApiKey'], (result: { developerModeEnabled?: boolean; deepgramApiKey?: string }) => {
@@ -814,8 +824,39 @@ export default function SidePanel() {
         </div>
       </div>
 
-      {/* DUAL-VIEW MAIN CONTENT */}
-      {environment === 'sandbox' ? (
+      {/* Live / History Toggle */}
+      <div className="flex border-b border-[#E0E4E8] bg-white">
+        <button
+          onClick={() => setViewMode('live')}
+          className={`flex-1 py-2 text-sm font-medium transition-colors ${
+            viewMode === 'live'
+              ? 'text-[#1B1F6B] border-b-2 border-[#1B1F6B]'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Live
+        </button>
+        <button
+          onClick={() => setViewMode('history')}
+          className={`flex-1 py-2 text-sm font-medium transition-colors ${
+            viewMode === 'history'
+              ? 'text-[#1B1F6B] border-b-2 border-[#1B1F6B]'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          History
+        </button>
+      </div>
+
+      {/* HISTORY VIEW */}
+      {viewMode === 'history' && (
+        <div className="flex-1 overflow-hidden">
+          <HistoryTab agentEmail={userEmail} />
+        </div>
+      )}
+
+      {/* DUAL-VIEW MAIN CONTENT (Live) */}
+      {viewMode === 'live' && (environment === 'sandbox' ? (
         /* ========== SANDBOX MODE VIEW ========== */
         <div className="flex-1 overflow-y-auto flex flex-col">
           {/* Sandbox Header */}
@@ -1029,7 +1070,7 @@ export default function SidePanel() {
             />
           </div>
         </div>
-      )}
+      ))}
 
       {/* Footer Stats */}
       {!threadExpanded && (transcriptions.length > 0 || callState === "active") && (

--- a/src/utils/history-store.ts
+++ b/src/utils/history-store.ts
@@ -1,0 +1,295 @@
+/**
+ * Call History Store — IndexedDB wrapper
+ *
+ * Persists completed call transcripts locally on the agent's machine.
+ * Fire-and-forget: never throws to the caller; logs warnings on failure.
+ * Zero cloud cost — everything stays in the browser.
+ */
+
+export interface HistoryTranscriptEntry {
+  speaker: 'agent' | 'customer';
+  text: string;
+  timestamp: number;
+}
+
+export interface HistoryIntelligence {
+  sentiment?: {
+    label?: string;
+    score?: number;
+    averageScore?: number;
+  };
+  intents?: Array<{ intent: string; confidence?: number; segment?: string }>;
+  topics?: Array<{ topic: string; confidence?: number; segment?: string }>;
+  summary?: string;
+}
+
+export interface HistoryEntities {
+  businessNames?: string[];
+  contactInfo?: {
+    emails?: string[];
+    phoneNumbers?: string[];
+    urls?: string[];
+  };
+  locations?: string[];
+  dates?: string[];
+  people?: string[];
+  websiteStatus?: 'has_website' | 'no_website' | 'unknown';
+}
+
+export interface CallHistoryRecord {
+  conversationId: string;
+  agentEmail: string;
+  startedAt: number;
+  endedAt: number;
+  destination?: string;
+  transcript: HistoryTranscriptEntry[];
+  intelligence?: HistoryIntelligence | null;
+  entities?: HistoryEntities | null;
+  savedAt: number;
+  schemaVersion: number;
+}
+
+const DB_NAME = 'call-coach-history';
+const STORE_NAME = 'transcripts';
+const DB_VERSION = 1;
+const CURRENT_SCHEMA = 1;
+
+const PRUNE_OLDER_THAN_DAYS = 90;
+const PRUNE_OLDER_THAN_MS = PRUNE_OLDER_THAN_DAYS * 24 * 60 * 60 * 1000;
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+/**
+ * Open (or create) the history database. Idempotent — safe to call repeatedly.
+ */
+function openDB(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+
+  const promise: Promise<IDBDatabase> = new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'conversationId' });
+        store.createIndex('agentEmail', 'agentEmail', { unique: false });
+        store.createIndex('endedAt', 'endedAt', { unique: false });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('IndexedDB open failed'));
+  });
+
+  // Clear cache on failure so future calls can retry
+  promise.catch(() => {
+    dbPromise = null;
+  });
+
+  dbPromise = promise;
+  return promise;
+}
+
+/**
+ * Save a completed call's transcript.
+ * Never throws — logs and returns false on failure.
+ */
+export async function saveTranscript(params: {
+  conversationId: string;
+  agentEmail: string;
+  startedAt: number;
+  endedAt: number;
+  destination?: string;
+  transcript: HistoryTranscriptEntry[];
+  intelligence?: HistoryIntelligence | null;
+  entities?: HistoryEntities | null;
+}): Promise<boolean> {
+  try {
+    if (!params.conversationId) {
+      console.warn('[HistoryStore] saveTranscript skipped — no conversationId');
+      return false;
+    }
+    if (!params.transcript || params.transcript.length === 0) {
+      console.warn('[HistoryStore] saveTranscript skipped — empty transcript');
+      return false;
+    }
+
+    const db = await openDB();
+    const record: CallHistoryRecord = {
+      conversationId: params.conversationId,
+      agentEmail: params.agentEmail || 'unknown',
+      startedAt: params.startedAt,
+      endedAt: params.endedAt,
+      destination: params.destination,
+      transcript: params.transcript,
+      intelligence: params.intelligence ?? null,
+      entities: params.entities ?? null,
+      savedAt: Date.now(),
+      schemaVersion: CURRENT_SCHEMA,
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.put(record);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error || new Error('put failed'));
+    });
+
+    console.log(`[HistoryStore] Saved transcript for conversation ${params.conversationId.slice(0, 8)}... (${params.transcript.length} entries)`);
+    return true;
+  } catch (err) {
+    console.warn('[HistoryStore] saveTranscript failed:', err);
+    return false;
+  }
+}
+
+/**
+ * Get a single call transcript by conversationId.
+ */
+export async function getTranscript(conversationId: string): Promise<CallHistoryRecord | null> {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const req = tx.objectStore(STORE_NAME).get(conversationId);
+      req.onsuccess = () => resolve((req.result as CallHistoryRecord) || null);
+      req.onerror = () => reject(req.error || new Error('get failed'));
+    });
+  } catch (err) {
+    console.warn('[HistoryStore] getTranscript failed:', err);
+    return null;
+  }
+}
+
+/**
+ * List calls for an agent, newest first.
+ */
+export async function listTranscripts(params?: {
+  agentEmail?: string;
+  limit?: number;
+}): Promise<CallHistoryRecord[]> {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      const index = store.index('endedAt');
+
+      const results: CallHistoryRecord[] = [];
+      const limit = params?.limit;
+      const filterEmail = params?.agentEmail;
+
+      // Cursor in descending order (newest first)
+      const cursorRequest = index.openCursor(null, 'prev');
+
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result;
+        if (!cursor) {
+          resolve(results);
+          return;
+        }
+
+        const record = cursor.value as CallHistoryRecord;
+        if (!filterEmail || record.agentEmail === filterEmail) {
+          results.push(record);
+        }
+
+        if (limit && results.length >= limit) {
+          resolve(results);
+          return;
+        }
+
+        cursor.continue();
+      };
+
+      cursorRequest.onerror = () => reject(cursorRequest.error || new Error('cursor failed'));
+    });
+  } catch (err) {
+    console.warn('[HistoryStore] listTranscripts failed:', err);
+    return [];
+  }
+}
+
+/**
+ * Delete a specific call transcript.
+ */
+export async function deleteTranscript(conversationId: string): Promise<boolean> {
+  try {
+    const db = await openDB();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const req = tx.objectStore(STORE_NAME).delete(conversationId);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error || new Error('delete failed'));
+    });
+    return true;
+  } catch (err) {
+    console.warn('[HistoryStore] deleteTranscript failed:', err);
+    return false;
+  }
+}
+
+/**
+ * Delete calls older than the retention window. Returns count removed.
+ */
+export async function pruneOldTranscripts(): Promise<number> {
+  try {
+    const cutoff = Date.now() - PRUNE_OLDER_THAN_MS;
+    const db = await openDB();
+
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const index = store.index('endedAt');
+
+      let removed = 0;
+      const range = IDBKeyRange.upperBound(cutoff);
+      const cursorRequest = index.openCursor(range);
+
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result;
+        if (!cursor) {
+          if (removed > 0) {
+            console.log(`[HistoryStore] Pruned ${removed} call(s) older than ${PRUNE_OLDER_THAN_DAYS} days`);
+          }
+          resolve(removed);
+          return;
+        }
+        cursor.delete();
+        removed++;
+        cursor.continue();
+      };
+
+      cursorRequest.onerror = () => reject(cursorRequest.error || new Error('prune cursor failed'));
+    });
+  } catch (err) {
+    console.warn('[HistoryStore] pruneOldTranscripts failed:', err);
+    return 0;
+  }
+}
+
+/**
+ * Count total records (optionally per agent). For diagnostics.
+ */
+export async function countTranscripts(agentEmail?: string): Promise<number> {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      if (agentEmail) {
+        const req = store.index('agentEmail').count(IDBKeyRange.only(agentEmail));
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      } else {
+        const req = store.count();
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      }
+    });
+  } catch (err) {
+    console.warn('[HistoryStore] countTranscripts failed:', err);
+    return 0;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 const manifest: ManifestV3Export = {
   manifest_version: 3,
   name: "Simple.biz Call Coach",
-  version: "2.2.7",
+  version: "2.2.8",
   description: "Real-time AI-powered call coaching with AWS Lambda backend, conversation intelligence, and Developer Mode for offline testing",
   icons: {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary

Save each completed call locally (IndexedDB) on the agent's machine and add a History tab to the sidebar for reviewing past transcripts, intelligence, and downloading TXT/JSON exports.

**Zero cloud cost** — everything stored locally. Cloud DB remains unchanged.

## What's included

### Data layer
- \`src/utils/history-store.ts\` — IndexedDB wrapper (\`saveTranscript\`, \`listTranscripts\`, \`getTranscript\`, \`pruneOldTranscripts\`, \`deleteTranscript\`, \`countTranscripts\`)
- Schema: per-call record with conversationId, agentEmail, startedAt, endedAt, destination, transcript entries, intelligence snapshot, entities snapshot
- 90-day auto-prune on extension startup

### Background hooks
- \`src/background/index.ts\` — On \`CALL_ENDED\` (port + runtime + webhook paths), snapshot state and save to IndexedDB
- \`currentCallStartedAt\`, \`currentCallDestination\` tracked per call
- \`latestIntelligence\` + \`latestEntities\` stashed on \`INTELLIGENCE_UPDATE\` for inclusion in history record
- All fields cleared on each new \`CALL_STARTED\`

### UI
- \`src/components/HistoryTab.tsx\` — List view grouped by day (Today / Yesterday / date)
  - Label cascade: phone > customer name > business > date/time (no "Unknown")
  - Secondary row: top intent outcome + color-coded sentiment
- \`src/components/TranscriptDetail.tsx\` — Chat-bubble style transcript view
  - Intelligence panel: sentiment, confidence, business, website status, phone, email, website, location, dates, people, intents, topics, summary
  - TXT and JSON download buttons (matches live-view export format)
- \`src/sidepanel/SidePanel.tsx\` — Live / History toggle at top of sidebar

### Docs
- \`doc/plans/2026-04-20-local-call-history-storage.md\` — Full plan/spec
- \`doc/eod/2026-04-15-call-coach-EOD.md\`, \`doc/eod/2026-04-17-call-coach-EOD.md\` — Backfilled EODs
- \`doc/requests/2026-04-20-weekly-billing-usage-request.md\` — Weekly billing request for Cobb

## Version
- \`2.2.7\` → \`2.2.8\`

## Cost impact
- **$0/month** — IndexedDB is local browser storage, no AWS or third-party APIs touched
- Disk: ~30-50 KB per call × 90-day retention = <100 MB worst case per agent
- Survives Chrome Web Store updates (IndexedDB persists across extension versions)

## Test plan
- [x] Completed a real CallTools call → transcript appears in History tab
- [x] Click a history entry → transcript + intelligence panel display correctly
- [x] TXT download produces readable export with intelligence dashboard
- [x] JSON download produces valid full record
- [x] Labels fall back gracefully when no phone number is captured
- [x] Call duration and time display correctly

## Rollback
Pure frontend + IndexedDB. \`git revert\` + \`npm run build\` + reload extension. Stale IndexedDB records are harmless.