### PR TITLE
feat(history): filters, multi-select, bulk actions (v2.2.9)

### DIFF
--- a/doc/plans/2026-04-21-call-history-management.md
+++ b/doc/plans/2026-04-21-call-history-management.md
@@ -1,0 +1,324 @@
+# Plan: Call History Management — Filters, Multi-Select, Bulk Actions
+
+**Date:** April 21, 2026
+**Author:** Kayser B
+**Status:** Draft — pending review
+**Target version:** v2.2.9
+**Depends on:** v2.2.8 — PR #71 (feat/local-call-history) merged
+
+---
+
+## Goal
+
+Add full-featured history management to the Call History tab:
+
+1. **Single-call delete** — trash icon per row with confirmation
+2. **Filter chips** — multi-select: Positive / Negative / Interested / Not interested / Callback agreed
+3. **Date range filter** — Today / Last 7 days / Last 30 days / All
+4. **Multi-select mode** — checkboxes, select all, bulk actions
+5. **Bulk actions** — delete selected, download selected as TXT / JSON
+6. **Download all (filtered)** — single-click export of everything currently visible
+
+**Non-goals for this PR:**
+- Search by customer/business name (future)
+- Custom date range picker (presets only)
+- Cloud sync or S3 export
+
+**Zero cloud cost** — all operations are local (IndexedDB + browser download).
+
+---
+
+## Features
+
+### 1. Single-call delete
+
+Trash icon on each row in the history list.
+
+```
+John Doe                                    🗑️
+Callback agreed · Positive
+Today · 4:00 PM · 3m 28s
+```
+
+- Click trash → native `confirm()` dialog: *"Delete this call transcript?"*
+- On confirm: `deleteTranscript(conversationId)` → remove from list optimistically
+- Icon has `stopPropagation` so it doesn't also open the detail view
+
+---
+
+### 2. Filter bar — sentiment + intent (multi-select)
+
+Horizontal chip bar at the top of the list. **Multiple chips can be active at once** (combines with AND across categories, OR within a category).
+
+```
+┌─────────────────────────────────────────────────┐
+│  [Today ▾]  [ Positive ]  [ Negative ]          │
+│  [ Interested ]  [ Not interested ]              │
+│  [ Callback agreed ]                             │
+└─────────────────────────────────────────────────┘
+```
+
+**Filter groups:**
+
+| Group | Chips | Mode |
+|-------|-------|:----:|
+| Sentiment | Positive, Negative | Multi (OR) |
+| Intent | Interested, Not interested, Callback agreed | Multi (OR) |
+
+**Logic:** `(any active sentiment matches) AND (any active intent matches)`.
+If no chips are active in a group, that group doesn't filter.
+
+**Example:**
+- `Positive` + `Interested` + `Callback agreed` active
+- Shows calls where sentiment is positive AND (interested OR callback agreed)
+
+**Styling:**
+- Active chip: solid `bg-[#1B1F6B] text-white`
+- Inactive chip: outlined `border border-[#dddddd] text-[#333333]`
+
+---
+
+### 3. Date range filter
+
+Dropdown/button at the far left of the filter bar.
+
+```
+[ Today ▾ ]
+  └─ Today
+     Last 7 days
+     Last 30 days
+     All time
+```
+
+**Logic:**
+
+| Option | Filter |
+|--------|--------|
+| Today | `endedAt >= todayStart` |
+| Last 7 days | `endedAt >= now - 7 days` |
+| Last 30 days | `endedAt >= now - 30 days` |
+| All time | No filter (default) |
+
+Starts on **All time** by default on mount.
+
+---
+
+### 4. Multi-select mode
+
+Toggleable mode. When OFF: rows are clickable to open details. When ON: checkboxes appear, clicks toggle selection.
+
+**Entering multi-select:**
+Small "Select" link in the header toggles it.
+
+```
+Call History        [Select]  🔄  📥
+```
+
+**In multi-select mode:**
+```
+Call History                    [Cancel]
+  ┌─────────────────────────────────────┐
+  │ ☑️  Select all (12 calls)           │
+  └─────────────────────────────────────┘
+
+  ☑️  📞 John Doe
+     Callback agreed · Positive
+
+  ☐  📞 Mickey Smith
+     Not interested · Neutral
+```
+
+When at least 1 item is selected, a **floating action bar** appears at the bottom:
+
+```
+┌────────────────────────────────────────┐
+│ 3 selected                              │
+│ [🗑️ Delete] [📥 TXT] [📥 JSON] [Cancel]│
+└────────────────────────────────────────┘
+```
+
+**Behavior:**
+- Delete: native `confirm("Delete 3 transcripts?")` → batch `deleteTranscript()` calls
+- Download TXT: one bundled TXT file with all selected calls
+- Download JSON: one JSON file containing an array of selected records
+- Cancel: exits multi-select, clears selection
+
+---
+
+### 5. "Download all (filtered)" shortcut
+
+The 📥 button in the header (not multi-select mode) downloads all currently-visible (i.e., filtered) calls into one TXT file.
+
+```
+Call Coach History Export
+Date range: Last 7 days
+Filters: Positive, Callback agreed
+Exported: Apr 20, 2026 5:45 PM
+Total calls: 12
+
+=====================================
+CALL 1 of 12
+=====================================
+[full transcript with intelligence dashboard]
+
+=====================================
+CALL 2 of 12
+=====================================
+...
+```
+
+**Filename:** `call-coach-history-{date-range}-{YYYY-MM-DD}.txt`
+e.g. `call-coach-history-last-7-days-2026-04-20.txt`
+
+---
+
+## Files to Change
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `src/components/HistoryTab.tsx` | Complete overhaul — adds filter bar, multi-select state, checkboxes, floating action bar, delete handlers, bulk download |
+| `package.json`, `vite.config.ts`, `src/background/index.ts` | Version bump 2.2.8 → 2.2.9 |
+
+### No changes to
+
+- `src/utils/history-store.ts` — `deleteTranscript()` already exists, maybe add `deleteTranscripts(ids[])` for bulk
+- `src/components/TranscriptDetail.tsx` — unchanged
+- Background lambda / infra — all client-side
+
+### Possibly new (helper module)
+
+- `src/utils/history-export.ts` — extracts the TXT bundling logic so it's reusable between per-call download, "download all", and bulk multi-select download
+
+---
+
+## State Shape
+
+```typescript
+// HistoryTab component state
+const [calls, setCalls]         = useState<CallHistoryRecord[]>([]);
+const [selected, setSelected]   = useState<CallHistoryRecord | null>(null); // detail view
+const [loading, setLoading]     = useState(true);
+
+// NEW
+const [dateRange, setDateRange] = useState<'today' | '7d' | '30d' | 'all'>('all');
+const [sentimentFilters, setSentimentFilters] = useState<Set<'positive' | 'negative'>>(new Set());
+const [intentFilters, setIntentFilters]       = useState<Set<string>>(new Set());
+const [multiSelectMode, setMultiSelectMode]   = useState(false);
+const [selectedIds, setSelectedIds]           = useState<Set<string>>(new Set());
+```
+
+Filter is derived (no re-fetch needed):
+```typescript
+const filtered = useMemo(
+  () => calls.filter(c => matchesFilter(c, { dateRange, sentimentFilters, intentFilters })),
+  [calls, dateRange, sentimentFilters, intentFilters]
+);
+```
+
+---
+
+## Data Flow
+
+### Single delete
+```
+Click trash → confirm() → deleteTranscript(id) →
+  setCalls(calls => calls.filter(c => c.conversationId !== id))
+```
+
+### Batch delete
+```
+Enter multi-select → select IDs → click Delete →
+  confirm(`Delete ${n} transcripts?`) →
+  Promise.all(ids.map(deleteTranscript)) →
+  setCalls(calls => calls.filter(c => !selectedIds.has(c.conversationId))) →
+  exit multi-select
+```
+
+### Batch download (TXT)
+```
+Click TXT in action bar →
+  buildBundleText(selectedRecords, { dateRange, filters }) →
+  downloadBlob(text, filename, 'text/plain') →
+  exit multi-select
+```
+
+---
+
+## Effort
+
+| Task | Time |
+|------|:----:|
+| Extract `history-export.ts` helper (reuse across 3 download actions) | 1 hr |
+| Date range dropdown + filter logic | 45 min |
+| Sentiment + intent chip bar (multi-select) | 1 hr |
+| Single delete button + confirm | 45 min |
+| Multi-select mode (toggle, checkboxes, select all) | 1.5 hrs |
+| Floating action bar (delete / TXT / JSON / cancel) | 1 hr |
+| "Download all (filtered)" header button | 30 min |
+| Empty states ("No calls match filters", "No calls to select") | 30 min |
+| Styling polish + mobile-narrow layout testing | 1 hr |
+| Version bump + commit + PR | 30 min |
+| **Total** | **~8 hrs (1 day)** |
+
+---
+
+## Testing
+
+Manual:
+1. Complete 6+ calls with varied outcomes (positive/negative, different intents, spread over several days)
+2. Open History → all calls visible
+3. Apply Date Range "Today" → verify list narrows
+4. Toggle "Positive" chip → combines with date filter
+5. Toggle "Interested" chip → combines further
+6. Click trash on one call → confirm → call disappears
+7. Tap "Select" → checkboxes appear → select 3 → action bar shows "3 selected"
+8. Click "Delete" in action bar → confirm → 3 calls removed
+9. Re-enter multi-select → select all → "Download TXT" → verify bundled TXT
+10. Click "Download JSON" → verify valid JSON array
+11. Exit multi-select → Download all (header 📥) → verify respects active filters
+12. Clear filters → verify all records return
+
+---
+
+## Open Questions
+
+1. **Multi-select toggle — explicit button or long-press?** Recommend: **explicit "Select" button** — discoverable and keyboard-friendly. Long-press is hidden.
+
+2. **Delete confirmation — native `confirm()` or custom modal?** Recommend: **native for v2.2.9**. Can polish to a styled modal later if ugly.
+
+3. **Filter chips — multi-select or single-select?** Recommend: **multi-select** (as drafted) — more powerful for manager reviews. Default state is "none active" = show all.
+
+4. **Date range presets — include custom date picker?** Recommend: **presets only for v2.2.9**. Custom range picker is a future PR.
+
+5. **Selection persists when switching filters?** E.g., select 3 calls → toggle filter → some are now hidden. Are they still selected? Recommend: **yes, selection persists but only visible items show in "X selected" count**. Simpler state model.
+
+6. **Download scope in multi-select — only selected, or all filtered?** Recommend: **only selected**. Header 📥 button handles "all filtered" scenario. Keeps each button's purpose clear.
+
+---
+
+## Rollback
+
+Pure frontend, additive. `git revert` + rebuild. No data migration needed.
+
+---
+
+## Summary
+
+- **1 file overhauled** (`HistoryTab.tsx`) + 1 new helper
+- **6 new behaviors** (delete, sentiment filter, intent filter, date range filter, multi-select, bulk actions)
+- **~1 day of work**
+- **Zero cloud cost**
+- **Reversible** via simple revert
+
+If you approve, I'll implement in this order:
+1. `history-export.ts` helper
+2. Date range dropdown
+3. Sentiment + intent chips
+4. Single delete
+5. Multi-select mode
+6. Bulk action bar + batch downloads
+7. Download all shortcut
+
+Each step buildable + testable independently.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devassist-call-coach",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1303,7 +1303,7 @@ async function connectAIBackend() {
       {
         source: 'devassist-call-coach',
         tabId: extensionState.tabId,
-        version: '2.2.8',
+        version: '2.2.9',
       }
     )
 

--- a/src/components/HistoryTab.tsx
+++ b/src/components/HistoryTab.tsx
@@ -1,23 +1,59 @@
-import { useEffect, useState } from 'react';
-import { Phone, ChevronRight, RefreshCw } from 'lucide-react';
-import { listTranscripts, type CallHistoryRecord } from '@/utils/history-store';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Phone, ChevronRight, RefreshCw, Trash2, Download, X, Check } from 'lucide-react';
+import {
+  listTranscripts,
+  deleteTranscript,
+  type CallHistoryRecord,
+} from '@/utils/history-store';
+import {
+  downloadBundleAsText,
+  downloadBundleAsJSON,
+  getCallLabel,
+} from '@/utils/history-export';
 import { TranscriptDetail } from './TranscriptDetail';
 
 interface HistoryTabProps {
   agentEmail?: string | null;
 }
 
+type DateRange = 'today' | '7d' | '30d' | 'all';
+type Sentiment = 'positive' | 'negative';
+type IntentFilter = 'interested' | 'not_interested' | 'request_callback';
+
+const INTENT_LABELS: Record<IntentFilter, string> = {
+  interested: 'Interested',
+  not_interested: 'Not interested',
+  request_callback: 'Callback agreed',
+};
+
+const DATE_RANGE_LABELS: Record<DateRange, string> = {
+  today: 'Today',
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days',
+  all: 'All time',
+};
+
 export function HistoryTab({ agentEmail }: HistoryTabProps) {
   const [calls, setCalls] = useState<CallHistoryRecord[]>([]);
   const [selected, setSelected] = useState<CallHistoryRecord | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // Filters
+  const [dateRange, setDateRange] = useState<DateRange>('all');
+  const [sentimentFilters, setSentimentFilters] = useState<Set<Sentiment>>(new Set());
+  const [intentFilters, setIntentFilters] = useState<Set<IntentFilter>>(new Set());
+  const [dateMenuOpen, setDateMenuOpen] = useState(false);
+
+  // Multi-select
+  const [multiSelect, setMultiSelect] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const loadCalls = async () => {
     setLoading(true);
     try {
       const results = await listTranscripts({
         agentEmail: agentEmail || undefined,
-        limit: 200,
+        limit: 500,
       });
       setCalls(results);
     } finally {
@@ -29,13 +65,117 @@ export function HistoryTab({ agentEmail }: HistoryTabProps) {
     loadCalls();
   }, [agentEmail]);
 
+  // ── Filtering ──
+  const filtered = useMemo(
+    () => calls.filter(c => matchesFilter(c, { dateRange, sentimentFilters, intentFilters })),
+    [calls, dateRange, sentimentFilters, intentFilters]
+  );
+
+  const activeFilterLabels = useMemo(() => {
+    const labels: string[] = [];
+    sentimentFilters.forEach(s => labels.push(capitalize(s)));
+    intentFilters.forEach(i => labels.push(INTENT_LABELS[i]));
+    return labels;
+  }, [sentimentFilters, intentFilters]);
+
+  const hasActiveFilters = dateRange !== 'all' || sentimentFilters.size > 0 || intentFilters.size > 0;
+
+  const clearFilters = () => {
+    setDateRange('all');
+    setSentimentFilters(new Set());
+    setIntentFilters(new Set());
+  };
+
+  // ── Multi-select helpers ──
+  const enterMultiSelect = () => {
+    setMultiSelect(true);
+    setSelectedIds(new Set());
+  };
+  const exitMultiSelect = () => {
+    setMultiSelect(false);
+    setSelectedIds(new Set());
+  };
+  const toggleId = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const allVisibleSelected =
+    filtered.length > 0 && filtered.every(c => selectedIds.has(c.conversationId));
+  const toggleSelectAll = () => {
+    if (allVisibleSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(filtered.map(c => c.conversationId)));
+    }
+  };
+
+  const selectedRecords = useMemo(
+    () => filtered.filter(c => selectedIds.has(c.conversationId)),
+    [filtered, selectedIds]
+  );
+
+  // ── Delete handlers ──
+  const handleDeleteSingle = async (id: string) => {
+    if (!confirm('Delete this call transcript? This cannot be undone.')) return;
+    await deleteTranscript(id);
+    setCalls(prev => prev.filter(c => c.conversationId !== id));
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
+  const handleDeleteSelected = async () => {
+    const count = selectedIds.size;
+    if (count === 0) return;
+    if (!confirm(`Delete ${count} transcript${count === 1 ? '' : 's'}? This cannot be undone.`)) return;
+
+    const ids = Array.from(selectedIds);
+    await Promise.all(ids.map(id => deleteTranscript(id)));
+    setCalls(prev => prev.filter(c => !selectedIds.has(c.conversationId)));
+    exitMultiSelect();
+  };
+
+  // ── Download handlers ──
+  const filenameSuffix = () => {
+    const parts: string[] = [];
+    if (dateRange !== 'all') parts.push(DATE_RANGE_LABELS[dateRange].toLowerCase().replace(/\s+/g, '-'));
+    sentimentFilters.forEach(s => parts.push(s));
+    intentFilters.forEach(i => parts.push(i.replace(/_/g, '-')));
+    if (parts.length === 0) return 'all';
+    return parts.join('_');
+  };
+
+  const handleDownloadAll = () => {
+    if (filtered.length === 0) return;
+    downloadBundleAsText(filtered, filenameSuffix(), {
+      dateRange: DATE_RANGE_LABELS[dateRange],
+      filters: activeFilterLabels,
+    });
+  };
+
+  const handleBulkDownloadText = () => {
+    if (selectedRecords.length === 0) return;
+    downloadBundleAsText(selectedRecords, `selected-${selectedRecords.length}`, {
+      filters: activeFilterLabels,
+    });
+    exitMultiSelect();
+  };
+
+  const handleBulkDownloadJSON = () => {
+    if (selectedRecords.length === 0) return;
+    downloadBundleAsJSON(selectedRecords, `selected-${selectedRecords.length}`);
+    exitMultiSelect();
+  };
+
+  // ── Detail view takeover ──
   if (selected) {
-    return (
-      <TranscriptDetail
-        record={selected}
-        onBack={() => setSelected(null)}
-      />
-    );
+    return <TranscriptDetail record={selected} onBack={() => setSelected(null)} />;
   }
 
   if (loading) {
@@ -57,84 +197,400 @@ export function HistoryTab({ agentEmail }: HistoryTabProps) {
     );
   }
 
-  const grouped = groupByDay(calls);
+  const grouped = groupByDay(filtered);
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700 shrink-0">
         <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
           Call History
         </h2>
-        <button
-          onClick={loadCalls}
-          className="p-1 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-          title="Refresh"
-        >
-          <RefreshCw className="w-4 h-4" />
-        </button>
+        <div className="flex items-center gap-2">
+          {!multiSelect ? (
+            <>
+              <button
+                onClick={enterMultiSelect}
+                className="text-xs font-medium text-[#1B1F6B] hover:underline"
+              >
+                Select
+              </button>
+              <button
+                onClick={handleDownloadAll}
+                disabled={filtered.length === 0}
+                className="p-1 text-gray-500 hover:text-gray-700 disabled:opacity-30 disabled:cursor-not-allowed"
+                title="Download all visible calls"
+              >
+                <Download className="w-4 h-4" />
+              </button>
+              <button
+                onClick={loadCalls}
+                className="p-1 text-gray-500 hover:text-gray-700"
+                title="Refresh"
+              >
+                <RefreshCw className="w-4 h-4" />
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={exitMultiSelect}
+              className="text-xs font-medium text-gray-500 hover:text-gray-700"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
       </div>
 
-      <div className="flex-1">
-        {grouped.map(({ label, items }) => (
-          <div key={label}>
-            <div className="sticky top-0 px-4 py-2 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 uppercase">
-              {label}
-            </div>
-            {items.map(call => {
-              const label = getCallLabel(call);
-              const outcome = getOutcomeLabel(call);
-              const sentiment = call.intelligence?.sentiment?.label;
+      {/* Filter bar: date button kept outside scrollable chip row so its dropdown isn't clipped */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 shrink-0">
+        <DateRangeButton
+          dateRange={dateRange}
+          open={dateMenuOpen}
+          onToggle={() => setDateMenuOpen(v => !v)}
+          onSelect={range => {
+            setDateRange(range);
+            setDateMenuOpen(false);
+          }}
+        />
+        <div className="flex items-center gap-2 overflow-x-auto">
+          <Chip
+            active={sentimentFilters.has('positive')}
+            onClick={() => toggleInSet(sentimentFilters, setSentimentFilters, 'positive')}
+          >
+            Positive
+          </Chip>
+          <Chip
+            active={sentimentFilters.has('negative')}
+            onClick={() => toggleInSet(sentimentFilters, setSentimentFilters, 'negative')}
+          >
+            Negative
+          </Chip>
+          <Chip
+            active={intentFilters.has('interested')}
+            onClick={() => toggleInSet(intentFilters, setIntentFilters, 'interested')}
+          >
+            Interested
+          </Chip>
+          <Chip
+            active={intentFilters.has('not_interested')}
+            onClick={() => toggleInSet(intentFilters, setIntentFilters, 'not_interested')}
+          >
+            Not interested
+          </Chip>
+          <Chip
+            active={intentFilters.has('request_callback')}
+            onClick={() => toggleInSet(intentFilters, setIntentFilters, 'request_callback')}
+          >
+            Callback agreed
+          </Chip>
+        </div>
+      </div>
 
-              return (
-                <button
-                  key={call.conversationId}
-                  onClick={() => setSelected(call)}
-                  className="w-full flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800 text-left transition-colors"
-                >
-                  <Phone className="w-4 h-4 text-gray-400 shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                      {label}
-                    </div>
-                    {(outcome || sentiment) && (
-                      <div className="flex items-center gap-2 mt-0.5">
-                        {outcome && (
-                          <span className="text-xs font-medium text-[#1B1F6B] dark:text-blue-300">
-                            {outcome}
-                          </span>
-                        )}
-                        {sentiment && (
-                          <span className={`text-xs font-medium ${getSentimentClass(sentiment)}`}>
-                            · {capitalize(sentiment)}
-                          </span>
-                        )}
-                      </div>
-                    )}
-                    <div className="text-xs text-gray-500 flex items-center gap-2 mt-0.5">
-                      <span>{formatTime(call.endedAt)}</span>
-                      <span>·</span>
-                      <span>{formatDuration(call.startedAt, call.endedAt)}</span>
-                      <span>·</span>
-                      <span>{call.transcript.length} lines</span>
-                    </div>
-                  </div>
-                  <ChevronRight className="w-4 h-4 text-gray-400 shrink-0" />
-                </button>
-              );
-            })}
+      {/* Select-all row (multi-select mode) */}
+      {multiSelect && filtered.length > 0 && (
+        <div className="flex items-center gap-2 px-4 py-2 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 text-xs text-gray-700 dark:text-gray-300">
+          <button
+            onClick={toggleSelectAll}
+            className={`flex items-center justify-center w-4 h-4 rounded border ${
+              allVisibleSelected
+                ? 'bg-[#1B1F6B] border-[#1B1F6B]'
+                : 'border-gray-400 bg-white'
+            }`}
+          >
+            {allVisibleSelected && <Check className="w-3 h-3 text-white" />}
+          </button>
+          <span>
+            {allVisibleSelected ? 'Deselect all' : 'Select all'} ({filtered.length} call{filtered.length === 1 ? '' : 's'})
+          </span>
+        </div>
+      )}
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-48 text-center px-8 text-gray-500">
+            <p className="text-sm">No calls match these filters.</p>
+            {hasActiveFilters && (
+              <button
+                onClick={clearFilters}
+                className="mt-2 text-xs font-medium text-[#1B1F6B] hover:underline"
+              >
+                Clear filters
+              </button>
+            )}
           </div>
-        ))}
+        ) : (
+          grouped.map(({ label: dayLabel, items }) => (
+            <div key={dayLabel}>
+              <div className="sticky top-0 px-4 py-2 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 uppercase z-[1]">
+                {dayLabel}
+              </div>
+              {items.map(call => {
+                const callLabel = getCallLabel(call);
+                const outcome = getOutcomeLabel(call);
+                const sentiment = call.intelligence?.sentiment?.label;
+                const checked = selectedIds.has(call.conversationId);
+
+                return (
+                  <div
+                    key={call.conversationId}
+                    className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors group"
+                  >
+                    {multiSelect ? (
+                      <button
+                        onClick={() => toggleId(call.conversationId)}
+                        className={`flex items-center justify-center w-4 h-4 rounded border shrink-0 ${
+                          checked
+                            ? 'bg-[#1B1F6B] border-[#1B1F6B]'
+                            : 'border-gray-400 bg-white'
+                        }`}
+                        aria-label={checked ? 'Deselect' : 'Select'}
+                      >
+                        {checked && <Check className="w-3 h-3 text-white" />}
+                      </button>
+                    ) : (
+                      <Phone className="w-4 h-4 text-gray-400 shrink-0" />
+                    )}
+
+                    <button
+                      onClick={() =>
+                        multiSelect ? toggleId(call.conversationId) : setSelected(call)
+                      }
+                      className="flex-1 min-w-0 text-left"
+                    >
+                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                        {callLabel}
+                      </div>
+                      {(outcome || sentiment) && (
+                        <div className="flex items-center gap-2 mt-0.5">
+                          {outcome && (
+                            <span className="text-xs font-medium text-[#1B1F6B] dark:text-blue-300">
+                              {outcome}
+                            </span>
+                          )}
+                          {sentiment && (
+                            <span
+                              className={`text-xs font-medium ${getSentimentClass(sentiment)}`}
+                            >
+                              · {capitalize(sentiment)}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                      <div className="text-xs text-gray-500 flex items-center gap-2 mt-0.5">
+                        <span>{formatTime(call.endedAt)}</span>
+                        <span>·</span>
+                        <span>{formatDuration(call.startedAt, call.endedAt)}</span>
+                        <span>·</span>
+                        <span>{call.transcript.length} lines</span>
+                      </div>
+                    </button>
+
+                    {!multiSelect && (
+                      <>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDeleteSingle(call.conversationId);
+                          }}
+                          className="p-1 text-gray-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                          title="Delete"
+                          aria-label="Delete call"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                        <ChevronRight className="w-4 h-4 text-gray-400 shrink-0" />
+                      </>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ))
+        )}
       </div>
+
+      {/* Floating action bar (multi-select) */}
+      {multiSelect && selectedIds.size > 0 && (
+        <div className="flex items-center justify-between gap-2 px-4 py-3 bg-[#1B1F6B] text-white shrink-0">
+          <span className="text-xs font-medium">
+            {selectedIds.size} selected
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleDeleteSelected}
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-red-600 hover:bg-red-700 rounded"
+              title="Delete selected"
+            >
+              <Trash2 className="w-3 h-3" />
+              Delete
+            </button>
+            <button
+              onClick={handleBulkDownloadText}
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-white/20 hover:bg-white/30 rounded"
+              title="Download selected as text"
+            >
+              <Download className="w-3 h-3" />
+              TXT
+            </button>
+            <button
+              onClick={handleBulkDownloadJSON}
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-white/20 hover:bg-white/30 rounded"
+              title="Download selected as JSON"
+            >
+              <Download className="w-3 h-3" />
+              JSON
+            </button>
+            <button
+              onClick={exitMultiSelect}
+              className="p-1 hover:bg-white/20 rounded"
+              title="Cancel"
+              aria-label="Cancel multi-select"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
-// ── Helpers ──
+// ── Small sub-components ──
+
+function Chip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-2.5 py-1 text-xs font-medium rounded-full whitespace-nowrap transition-colors ${
+        active
+          ? 'bg-[#1B1F6B] text-white border border-[#1B1F6B]'
+          : 'bg-white dark:bg-gray-800 text-[#333333] dark:text-gray-300 border border-[#dddddd] dark:border-gray-600 hover:bg-gray-50'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function DateRangeButton({
+  dateRange,
+  open,
+  onToggle,
+  onSelect,
+}: {
+  dateRange: DateRange;
+  open: boolean;
+  onToggle: () => void;
+  onSelect: (r: DateRange) => void;
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        onToggle();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, onToggle]);
+
+  return (
+    <div ref={wrapRef} className="relative shrink-0">
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full bg-white dark:bg-gray-800 text-[#333333] dark:text-gray-300 border border-[#dddddd] dark:border-gray-600 hover:bg-gray-50 whitespace-nowrap"
+      >
+        {DATE_RANGE_LABELS[dateRange]}
+        <span className="text-gray-400">▾</span>
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg z-50 min-w-[140px]">
+          {(Object.keys(DATE_RANGE_LABELS) as DateRange[]).map(r => (
+            <button
+              key={r}
+              onClick={() => onSelect(r)}
+              className={`w-full text-left px-3 py-2 text-xs hover:bg-gray-50 dark:hover:bg-gray-700 ${
+                r === dateRange ? 'font-semibold text-[#1B1F6B]' : 'text-gray-700 dark:text-gray-300'
+              }`}
+            >
+              {DATE_RANGE_LABELS[r]}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Pure helpers ──
+
+function toggleInSet<T>(set: Set<T>, setter: (s: Set<T>) => void, value: T) {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  setter(next);
+}
+
+function matchesFilter(
+  call: CallHistoryRecord,
+  filters: {
+    dateRange: DateRange;
+    sentimentFilters: Set<Sentiment>;
+    intentFilters: Set<IntentFilter>;
+  }
+): boolean {
+  // Date range
+  if (filters.dateRange !== 'all') {
+    const now = Date.now();
+    let cutoff: number;
+    if (filters.dateRange === 'today') {
+      const t = new Date();
+      t.setHours(0, 0, 0, 0);
+      cutoff = t.getTime();
+    } else if (filters.dateRange === '7d') {
+      cutoff = now - 7 * 24 * 60 * 60 * 1000;
+    } else {
+      cutoff = now - 30 * 24 * 60 * 60 * 1000;
+    }
+    if (call.endedAt < cutoff) return false;
+  }
+
+  // Sentiment (OR within group)
+  if (filters.sentimentFilters.size > 0) {
+    const label = call.intelligence?.sentiment?.label as Sentiment | undefined;
+    if (!label || !filters.sentimentFilters.has(label)) return false;
+  }
+
+  // Intent (OR within group)
+  if (filters.intentFilters.size > 0) {
+    const callIntents = new Set(call.intelligence?.intents?.map(i => i.intent) ?? []);
+    let match = false;
+    filters.intentFilters.forEach(f => {
+      if (callIntents.has(f)) match = true;
+    });
+    if (!match) return false;
+  }
+
+  return true;
+}
 
 function groupByDay(calls: CallHistoryRecord[]) {
   const groups = new Map<string, CallHistoryRecord[]>();
   for (const c of calls) {
-    const label = dayLabel(c.endedAt);
+    const label = dayLabelFn(c.endedAt);
     const bucket = groups.get(label) ?? [];
     bucket.push(c);
     groups.set(label, bucket);
@@ -142,7 +598,7 @@ function groupByDay(calls: CallHistoryRecord[]) {
   return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
 }
 
-function dayLabel(ts: number): string {
+function dayLabelFn(ts: number): string {
   const d = new Date(ts);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -177,37 +633,10 @@ function formatDuration(startedAt: number, endedAt: number): string {
   return `${m}m ${s.toString().padStart(2, '0')}s`;
 }
 
-// ── Call labeling helpers ──
-
-function getCallLabel(call: CallHistoryRecord): string {
-  // Priority: phone > customer name > business > date/time fallback
-  if (call.destination) return call.destination;
-
-  const person = call.entities?.people?.[0];
-  if (person) return person;
-
-  const business = call.entities?.businessNames?.[0];
-  if (business) return business;
-
-  // Final fallback: date/time
-  const d = new Date(call.endedAt);
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
-}
-
-/**
- * Derive a short outcome label from intents + website status.
- * Returns null if there's nothing meaningful to show.
- */
 function getOutcomeLabel(call: CallHistoryRecord): string | null {
   const intents = call.intelligence?.intents || [];
   if (intents.length === 0) return null;
 
-  // Sort by confidence, pick top
   const top = [...intents].sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0];
   if (!top) return null;
 

--- a/src/components/TranscriptDetail.tsx
+++ b/src/components/TranscriptDetail.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Phone, Download } from 'lucide-react';
 import type { CallHistoryRecord, HistoryIntelligence, HistoryEntities } from '@/utils/history-store';
+import { downloadCallAsText, downloadCallAsJSON } from '@/utils/history-export';
 
 interface TranscriptDetailProps {
   record: CallHistoryRecord;
@@ -44,7 +45,7 @@ export function TranscriptDetail({ record, onBack }: TranscriptDetailProps) {
           </div>
         </div>
         <button
-          onClick={() => downloadAsText(record, label)}
+          onClick={() => downloadCallAsText(record, label)}
           className="flex items-center gap-1 px-2 py-1 text-xs bg-[#1B1F6B] hover:bg-[#14174f] text-white rounded transition-colors"
           title="Download as text"
         >
@@ -52,7 +53,7 @@ export function TranscriptDetail({ record, onBack }: TranscriptDetailProps) {
           TXT
         </button>
         <button
-          onClick={() => downloadAsJSON(record, label)}
+          onClick={() => downloadCallAsJSON(record, label)}
           className="flex items-center gap-1 px-2 py-1 text-xs bg-[#1B1F6B] hover:bg-[#14174f] text-white rounded transition-colors"
           title="Download as JSON"
         >
@@ -185,93 +186,4 @@ function formatWebsiteStatus(status: 'has_website' | 'no_website' | 'unknown' | 
   return '--';
 }
 
-// ── Downloads ──
-
-function safeFilename(s: string): string {
-  return s.replace(/[^a-z0-9\-_]/gi, '_').slice(0, 60);
-}
-
-function downloadBlob(content: string, filename: string, mime: string) {
-  const blob = new Blob([content], { type: mime });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
-}
-
-function downloadAsText(record: CallHistoryRecord, label: string) {
-  const endedDate = new Date(record.endedAt);
-  const durationSec = Math.max(0, Math.round((record.endedAt - record.startedAt) / 1000));
-  const m = Math.floor(durationSec / 60);
-  const s = durationSec % 60;
-  const durationStr = m === 0 ? `${s}s` : `${m}m ${s.toString().padStart(2, '0')}s`;
-
-  let text = `Call Transcript Export\n`;
-  text += `Call: ${label}\n`;
-  text += `Date: ${endedDate.toLocaleString()}\n`;
-  text += `Duration: ${durationStr}\n`;
-  text += `Total lines: ${record.transcript.length}\n`;
-
-  // Intelligence + entities dashboard
-  if (record.intelligence || record.entities) {
-    text += `\n${'='.repeat(50)}\n`;
-    text += `CONVERSATION INTELLIGENCE\n`;
-    text += `${'='.repeat(50)}\n\n`;
-
-    const s = record.intelligence?.sentiment;
-    if (s?.label) {
-      const scoreStr = typeof s.score === 'number' ? ` (${Math.round(s.score * 100)}% confidence)` : '';
-      text += `Sentiment: ${s.label}${scoreStr}\n`;
-    }
-
-    const e = record.entities;
-    if (e) {
-      if (e.businessNames?.length) text += `Business: ${e.businessNames.join(', ')}\n`;
-      if (e.websiteStatus && e.websiteStatus !== 'unknown') {
-        text += `Website Status: ${e.websiteStatus === 'has_website' ? 'Has Website' : 'No Website'}\n`;
-      }
-      if (e.contactInfo?.phoneNumbers?.length) text += `Phone: ${e.contactInfo.phoneNumbers.join(', ')}\n`;
-      if (e.contactInfo?.emails?.length) text += `Email: ${e.contactInfo.emails.join(', ')}\n`;
-      if (e.contactInfo?.urls?.length) text += `Website: ${e.contactInfo.urls.join(', ')}\n`;
-      if (e.locations?.length) text += `Location: ${e.locations.join(', ')}\n`;
-      if (e.dates?.length) text += `Dates: ${e.dates.join(', ')}\n`;
-      if (e.people?.length) text += `People: ${e.people.join(', ')}\n`;
-    }
-
-    if (record.intelligence?.intents?.length) {
-      text += `Intents: ${record.intelligence.intents.map(i => i.intent).join(', ')}\n`;
-    }
-    if (record.intelligence?.topics?.length) {
-      text += `Topics: ${record.intelligence.topics.map(t => t.topic).join(', ')}\n`;
-    }
-    if (record.intelligence?.summary) {
-      text += `\nSummary: ${record.intelligence.summary}\n`;
-    }
-  }
-
-  text += `\n${'='.repeat(50)}\n`;
-  text += `TRANSCRIPT\n`;
-  text += `${'='.repeat(50)}\n\n`;
-
-  record.transcript.forEach((entry) => {
-    const time = new Date(entry.timestamp).toLocaleTimeString(undefined, {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    });
-    const speaker = entry.speaker === 'agent' ? 'Agent' : 'Customer';
-    text += `[${time}] ${speaker}: ${entry.text}\n\n`;
-  });
-
-  const dateStr = endedDate.toISOString().slice(0, 10);
-  downloadBlob(text, `call-${safeFilename(label)}-${dateStr}.txt`, 'text/plain');
-}
-
-function downloadAsJSON(record: CallHistoryRecord, label: string) {
-  const endedDate = new Date(record.endedAt);
-  const json = JSON.stringify(record, null, 2);
-  const dateStr = endedDate.toISOString().slice(0, 10);
-  downloadBlob(json, `call-${safeFilename(label)}-${dateStr}.json`, 'application/json');
-}
+// Download helpers now live in @/utils/history-export (reused across views)

--- a/src/utils/history-export.ts
+++ b/src/utils/history-export.ts
@@ -1,0 +1,202 @@
+/**
+ * Call History Export Helpers
+ *
+ * Shared logic for exporting single calls or bundles of calls as TXT / JSON.
+ * Used by TranscriptDetail (single call) and HistoryTab (download all / bulk).
+ */
+
+import type { CallHistoryRecord } from './history-store';
+
+export interface BundleMeta {
+  dateRange?: string;
+  filters?: string[];
+}
+
+// ── File download ──
+
+export function safeFilename(s: string): string {
+  return s.replace(/[^a-z0-9\-_]/gi, '_').slice(0, 60);
+}
+
+export function downloadBlob(content: string, filename: string, mime: string) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Label helper (mirrors HistoryTab cascade) ──
+
+export function getCallLabel(record: CallHistoryRecord): string {
+  if (record.destination) return record.destination;
+
+  const person = record.entities?.people?.[0];
+  if (person) return person;
+
+  const business = record.entities?.businessNames?.[0];
+  if (business) return business;
+
+  const d = new Date(record.endedAt);
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatDurationStr(startedAt: number, endedAt: number): string {
+  const seconds = Math.max(0, Math.round((endedAt - startedAt) / 1000));
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m === 0) return `${s}s`;
+  return `${m}m ${s.toString().padStart(2, '0')}s`;
+}
+
+// ── Single-call TXT section ──
+
+/**
+ * Build the TXT representation of a single call.
+ * Used standalone (single download) and as a section in bundled exports.
+ */
+export function buildCallText(record: CallHistoryRecord, label?: string): string {
+  const callLabel = label ?? getCallLabel(record);
+  const endedDate = new Date(record.endedAt);
+  const durationStr = formatDurationStr(record.startedAt, record.endedAt);
+
+  let text = `Call: ${callLabel}\n`;
+  text += `Date: ${endedDate.toLocaleString()}\n`;
+  text += `Duration: ${durationStr}\n`;
+  text += `Total lines: ${record.transcript.length}\n`;
+
+  // Intelligence + entities dashboard
+  if (record.intelligence || record.entities) {
+    text += `\n${'─'.repeat(50)}\n`;
+    text += `CONVERSATION INTELLIGENCE\n`;
+    text += `${'─'.repeat(50)}\n\n`;
+
+    const s = record.intelligence?.sentiment;
+    if (s?.label) {
+      const scoreStr =
+        typeof s.score === 'number' ? ` (${Math.round(s.score * 100)}% confidence)` : '';
+      text += `Sentiment: ${s.label}${scoreStr}\n`;
+    }
+
+    const e = record.entities;
+    if (e) {
+      if (e.businessNames?.length) text += `Business: ${e.businessNames.join(', ')}\n`;
+      if (e.websiteStatus && e.websiteStatus !== 'unknown') {
+        text += `Website Status: ${e.websiteStatus === 'has_website' ? 'Has Website' : 'No Website'}\n`;
+      }
+      if (e.contactInfo?.phoneNumbers?.length)
+        text += `Phone: ${e.contactInfo.phoneNumbers.join(', ')}\n`;
+      if (e.contactInfo?.emails?.length)
+        text += `Email: ${e.contactInfo.emails.join(', ')}\n`;
+      if (e.contactInfo?.urls?.length)
+        text += `Website: ${e.contactInfo.urls.join(', ')}\n`;
+      if (e.locations?.length) text += `Location: ${e.locations.join(', ')}\n`;
+      if (e.dates?.length) text += `Dates: ${e.dates.join(', ')}\n`;
+      if (e.people?.length) text += `People: ${e.people.join(', ')}\n`;
+    }
+
+    if (record.intelligence?.intents?.length) {
+      text += `Intents: ${record.intelligence.intents.map((i) => i.intent).join(', ')}\n`;
+    }
+    if (record.intelligence?.topics?.length) {
+      text += `Topics: ${record.intelligence.topics.map((t) => t.topic).join(', ')}\n`;
+    }
+    if (record.intelligence?.summary) {
+      text += `\nSummary: ${record.intelligence.summary}\n`;
+    }
+  }
+
+  text += `\n${'─'.repeat(50)}\n`;
+  text += `TRANSCRIPT\n`;
+  text += `${'─'.repeat(50)}\n\n`;
+
+  record.transcript.forEach((entry) => {
+    const time = new Date(entry.timestamp).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    const speaker = entry.speaker === 'agent' ? 'Agent' : 'Customer';
+    text += `[${time}] ${speaker}: ${entry.text}\n\n`;
+  });
+
+  return text;
+}
+
+// ── Single-call download wrappers (used by TranscriptDetail) ──
+
+export function downloadCallAsText(record: CallHistoryRecord, label?: string) {
+  const callLabel = label ?? getCallLabel(record);
+  const endedDate = new Date(record.endedAt);
+  const dateStr = endedDate.toISOString().slice(0, 10);
+
+  let text = `Call Transcript Export\n`;
+  text += buildCallText(record, callLabel);
+
+  downloadBlob(text, `call-${safeFilename(callLabel)}-${dateStr}.txt`, 'text/plain');
+}
+
+export function downloadCallAsJSON(record: CallHistoryRecord, label?: string) {
+  const callLabel = label ?? getCallLabel(record);
+  const endedDate = new Date(record.endedAt);
+  const dateStr = endedDate.toISOString().slice(0, 10);
+  const json = JSON.stringify(record, null, 2);
+
+  downloadBlob(
+    json,
+    `call-${safeFilename(callLabel)}-${dateStr}.json`,
+    'application/json'
+  );
+}
+
+// ── Bundle builders (multiple calls in one file) ──
+
+export function buildBundleText(records: CallHistoryRecord[], meta?: BundleMeta): string {
+  let text = `Call Coach History Export\n`;
+  if (meta?.dateRange) text += `Date range: ${meta.dateRange}\n`;
+  if (meta?.filters?.length) text += `Filters: ${meta.filters.join(', ')}\n`;
+  text += `Exported: ${new Date().toLocaleString()}\n`;
+  text += `Total calls: ${records.length}\n`;
+
+  records.forEach((record, idx) => {
+    text += `\n${'='.repeat(50)}\n`;
+    text += `CALL ${idx + 1} of ${records.length}\n`;
+    text += `${'='.repeat(50)}\n\n`;
+    text += buildCallText(record);
+  });
+
+  return text;
+}
+
+// ── Bundle download wrappers ──
+
+export function downloadBundleAsText(
+  records: CallHistoryRecord[],
+  filenameSuffix: string,
+  meta?: BundleMeta
+) {
+  const text = buildBundleText(records, meta);
+  const dateStr = new Date().toISOString().slice(0, 10);
+  downloadBlob(
+    text,
+    `call-coach-history-${safeFilename(filenameSuffix)}-${dateStr}.txt`,
+    'text/plain'
+  );
+}
+
+export function downloadBundleAsJSON(records: CallHistoryRecord[], filenameSuffix: string) {
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const json = JSON.stringify({ exportedAt: Date.now(), count: records.length, calls: records }, null, 2);
+  downloadBlob(
+    json,
+    `call-coach-history-${safeFilename(filenameSuffix)}-${dateStr}.json`,
+    'application/json'
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 const manifest: ManifestV3Export = {
   manifest_version: 3,
   name: "Simple.biz Call Coach",
-  version: "2.2.8",
+  version: "2.2.9",
   description: "Real-time AI-powered call coaching with AWS Lambda backend, conversation intelligence, and Developer Mode for offline testing",
   icons: {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary

Add full-featured history management to the Call History tab — filters, delete, multi-select, and bulk download. **Zero cloud cost** — all client-side.

## What's new

### Filters
- **Date range** dropdown: Today / Last 7 days / Last 30 days / All time
- **Sentiment** chips: Positive / Negative (multi-select)
- **Intent** chips: Interested / Not interested / Callback agreed (multi-select)
- Filters combine with AND across groups, OR within a group
- Empty-state with "Clear filters" button when filters return zero results

### Delete
- Per-row trash icon (appears on hover) with native \`confirm()\`
- Optimistic remove from list, persists delete to IndexedDB

### Multi-select mode
- \`[Select]\` button in header enters multi-select
- Checkboxes appear on every row
- "Select all (N calls)" at the top
- Floating action bar at bottom: Delete / TXT / JSON / Cancel
- Bulk delete with batch confirm
- Bulk TXT → one bundled file with all selected calls
- Bulk JSON → array of full records

### Download all (filtered)
- 📥 button in header — bundles currently-visible (filtered) calls into one TXT
- Filename reflects active filters: \`call-coach-history-positive_interested-2026-04-21.txt\`
- TXT header includes filter + date range metadata

### Shared export module
- New \`src/utils/history-export.ts\` centralizes TXT/JSON bundling logic
- Reused by single-call download (TranscriptDetail) and bulk downloads (HistoryTab)
- Cleaner separation — \`TranscriptDetail.tsx\` no longer duplicates the format code

## Files changed

| File | Change |
|------|--------|
| \`src/utils/history-export.ts\` | **NEW** — shared export helpers (buildCallText, buildBundleText, downloadCallAsText/JSON, downloadBundleAsText/JSON) |
| \`src/components/HistoryTab.tsx\` | Rewritten — filters, multi-select, delete, bulk actions |
| \`src/components/TranscriptDetail.tsx\` | Simplified — uses shared helpers |
| \`package.json\`, \`vite.config.ts\`, \`src/background/index.ts\` | Version bump 2.2.8 → 2.2.9 |
| \`doc/plans/2026-04-21-call-history-management.md\` | Plan doc |

## Bug fix included

Date-range dropdown was invisible on first pass — the filter bar's \`overflow-x-auto\` was clipping the absolute-positioned menu. Moved the date button outside the scrollable chip row, bumped dropdown z-index to 50, and added click-outside-to-close behavior.

## Cost impact

**\$0/month.** Everything runs locally: IndexedDB for reads/writes, browser download API for exports. No AWS, no Anthropic, no Deepgram.

## Test plan

- [x] Date range: each option filters correctly (Today / 7d / 30d / All)
- [x] Sentiment chips: Positive/Negative toggle, multi-select works
- [x] Intent chips: Interested/Not interested/Callback agreed toggle
- [x] Filters combine: e.g., Positive + Interested shows intersection
- [x] Per-row delete: hover → trash icon → confirm → removes
- [x] Multi-select: toggle, checkbox, select all, action bar appears with count
- [x] Bulk delete: confirm dialog, removes all selected
- [x] Bulk TXT/JSON download: files download correctly
- [x] Download all: header 📥 respects filters
- [x] Empty state: "No calls match these filters" + clear button works
- [x] Date dropdown: opens, click outside closes, z-index above sticky headers

## Rollback

Pure frontend + IndexedDB. \`git revert\` + \`npm run build\` + reload extension. IndexedDB records unchanged.