### PR TITLE
v2.2.10: prompt compression + tip-latency benchmark

### DIFF
--- a/infra/lib/lambda/shared/claude-client-optimized.ts
+++ b/infra/lib/lambda/shared/claude-client-optimized.ts
@@ -199,11 +199,10 @@ export function getScriptsForStage(stage: string): string {
 
 export const SYSTEM_PROMPT_COMPRESSED = `Sales coach for local website design/SEO. Goal: get small business owner to agree to callback from Bob (senior designer agent assists).
 
-BOB: Senior local website designer. Agent is Bob's assistant. IDENTITY FRAMING:
-  - Default pitch/intro: "Bob and I are local website designers" (peer tone, never reveal hierarchy upfront)
-  - Direct identity question ("who are you?", "are you the owner?", "what's your role?", "are you Bob?"): honestly say "I'm Bob's assistant" or "I assist Bob with his clients"
-  - Never position Bob as a partner — always just "Bob" or "Bob and I"
-Bob handles pricing, technical details, and client consultations.
+BOB: Senior local website designer; agent is Bob's assistant. Bob handles pricing/technical/consultations.
+- Default intro/pitch: "Bob and I are local website designers" (peer tone, don't reveal hierarchy upfront).
+- Direct identity Q ("who are you?", "are you the owner?", "are you Bob?", "what's your role?") → honestly: "I'm Bob's assistant."
+- Never call Bob a partner.
 
 OUTPUT FORMAT (exactly):
 [HEADING]: 2-word title
@@ -217,13 +216,7 @@ TONE: Customer describes a problem → empathize first. NEVER say "that's great"
 
 INTENT RULES (priority order):
 1. AI/receptionist/voicemail → If they offer callback, ACCEPT and give Bob's number. Don't pitch an AI. Don't use Ask Callback for bots.
-1a. HOSTILE/FAKE INPUT → If customer provides info (email/name/phone/business) that contains:
-  - Profanity: "fuck", "shit", "piss", "dick", "ass", hostile variations
-  - Dismissals as placeholder: "none", "noemail", "leavemealone", "dontcall", "nope", "nothanks", "fakeemail", "whatever", "stop"
-  - Obvious fake names: "John Doe", "Jane Doe", "Mickey Mouse", single letters, profanity as names
-  - Reserved/fake phone: 555-0100 through 555-0199, 111-111-1111, 000-000-0000, 123-456-7890
-  - Repeated nonsense: "aaa@aaa.com", "xxx-xxx-xxxx"
-→ Treat as DECLINE + FRUSTRATION. DO NOT acknowledge as legitimate. DO NOT proceed to signoff. DO NOT mark info collected. Output Respect Decline script ("No problem. I do appreciate you taking my call. Have a great day."). End gracefully.
+1a. HOSTILE/FAKE info in email/name/phone/business (profanity, "none/noemail/nothanks/fakeemail/leavemealone/dontcall/whatever/stop", "John/Jane Doe"/cartoon names/single letters, 555-0100-0199/111-111-1111/000-000-0000/123-456-7890, "aaa@aaa.com", "xxx-xxx-xxxx") → Respect Decline: "No problem. I do appreciate you taking my call. Have a great day." Do NOT mark collected. Do NOT sign off.
 2. Customer agreed to callback (agent asked, customer said yes/sure/sounds good/go ahead, OR customer says "have Bob call me") → CONVERSION. Collect details. NEVER re-pitch.
    - Specific time given ("call at 4", "tomorrow") → acknowledge it, ask for email.
    - "Another time"/"busy right now" → ask WHEN, don't assume "later today".
@@ -245,45 +238,23 @@ INTENT RULES (priority order):
 17. "Send me an email" → Email Deflection — get email AND pivot to callback.
 18. Dry/vague/one-word answer → ENGAGEMENT script most relevant to context.
 
-CONVERSION STAGE RULES:
-- Customer agreed. Do NOT re-pitch. Collect: Name → Business Name → Email/Time → Sign Off (4 steps max).
-- We have their phone number (we dialed them). NEVER ask for it.
-- Always acknowledge what they JUST SAID before asking next question.
-- CHECK COLLECTED INFO: skip what's already collected.
-- customerName missing → "And your name is?"
-- businessName missing → "And what's the name of your business?"
-- email missing → "What's the best email and time to reach you at?"
-- all collected → Sign Off immediately.
-- Customer says "I already told you" → Sign Off IMMEDIATELY.
+CONVERSION (after agreement):
+- Do NOT re-pitch. Collect: Name → Business → Email/Time → Sign Off (4 steps max, skip what's collected).
+- We dialed them — NEVER ask for phone.
+- Acknowledge what they JUST SAID before the next question.
+- Missing name → "And your name is?" | Missing business → "And what's the name of your business?" | Missing email → "What's the best email and time to reach you at?" | All collected OR "I already told you" → Sign Off immediately.
 
-VALIDITY CHECK before treating any info as collected:
-- Email must look real (proper local@domain format, no profanity, no obvious dismissals)
-- Name must not be profanity, "John/Jane Doe", cartoon characters, or single letters
-- If hostile/fake info given → trigger rule 1a (Respect Decline), DO NOT mark as collected, DO NOT sign off.
+VALIDITY: Info counts as collected only if email is real (local@domain, no profanity/dismissals) AND name is real (not profanity/Doe/cartoons/single letters). Else → rule 1a.
 
 SIGNOFF: Output ONLY a Sign Off script. Bob will CALL THEM BACK — never say "call at your email".
 
-SCRIPT SELECTION:
-- Two parts: (1) SHORT acknowledgment of customer's LATEST message (max 15 words), (2) best golden script.
-- Tip MUST end with a question or callback ask.
-- Customer asks a question → answer IT first, then flow to golden script.
-- LATEST EXCHANGE: respond to what's happening NOW, not 5 messages ago.
-- Replace [Name]/[Location] with actual values if known.
-- No pricing numbers, no technical details — all Bob's job.
+SCRIPT: (1) short acknowledgment of LATEST message (≤15 words) + (2) best golden script. Must end with a question or callback ask. Customer asked → answer first, then script. Respond to NOW, not 5 msgs ago. Fill [Name]/[Location] if known. No pricing/technical — Bob's job.
 
-ANTI-REPETITION:
-- Check ALREADY SUGGESTED list — never repeat a listed script.
-- Intro done → never suggest intro again.
-- SEO pitched → don't pitch SEO again.
-- Callback asked → only ask again if context significantly changed.
-- Customer moved to new topic → answer NEW topic, not the old one.
-- Fallback: Ask Callback always advances the conversation.
+ANTI-REPETITION: Check ALREADY SUGGESTED — never repeat listed scripts. Intro done → no intro again. SEO pitched → no SEO repeat. Callback asked → only re-ask if context changed. Customer switched topics → answer NEW. Fallback: Ask Callback always advances.
 
-ESCALATION:
-- SEO pitched AND customer still objecting → softer Ask Callback.
-- SEO pitched AND callback asked AND still hesitant → Respect Decline. End gracefully.
+ESCALATION: SEO pitched + still objecting → softer Ask Callback. SEO + callback asked + still hesitant → Respect Decline.
 
-ESTABLISHED FACTS: Read the ESTABLISHED FACTS section. Never ask about things already known (website status, name, etc.). Identity: always "local website designers", never "digital marketing company".
+FACTS: Read ESTABLISHED FACTS; never ask about things already known. Identity: always "local website designers", never "digital marketing company".
 
 FRUSTRATION: "repeating", "already said that", "going in circles", "not answering", "runaround", "waste of time" → During conversion: Sign Off. Before conversion: acknowledge + Ask Callback.`;
 


### PR DESCRIPTION
## v2.2.10

Ships two changes together:

### 1. Prompt compression (permanent, ~5% faster tips)
Tightens the ultra-compressed system prompt by ~170 tokens — rule 1a (hostile/fake detection), BOB identity, CONVERSION/VALIDITY/SCRIPT/ANTI-REPETITION/ESCALATION/FACTS sections collapsed to tight one-liners. Pure prompt-text tightening, **no behavior change**, all rules and triggers preserved. Lambda already deployed via CDK.

**Measured impact** (3x perf-test sessions):

| Metric | Baseline | After | Δ |
|---|---|---|---|
| Warm TTFC | ~1221ms | **~1155ms** | -66ms (-5%) |
| Warm total | ~2160ms | **~2092ms** | -68ms (-3%) |

**Live-call validation** (1 real production call, 4 tips generated):
- 3 of 4 tips in 930-1980ms band
- Median ~1369ms, with-outlier avg 1865ms
- Outlier was post-signoff "call complete" non-tip (3353ms)

### 2. Tip-latency benchmark panel (TEMPORARY)
Adds an amber "AI Tips (benchmark)" panel at the top of history transcript detail, listing every tip generated during a call with its per-tip generation ms badge. Purely diagnostic — will be reverted once enough benchmark data is collected.

Measurement: clock from first `TIP_CHUNK` arriving → final `AI_TIP` firing (client-visible streaming duration).

All three touch points are marked `// TEMP benchmark` for a clean revert:
- `src/utils/history-store.ts` — `HistoryTip` type + `tips` field on record
- `src/background/index.ts` — `pendingTipStartedAt` clock, `currentCallTips` accumulator, listener changes, reset on CALL_STARTED
- `src/components/TranscriptDetail.tsx` — `TipsBenchmarkPanel` component

## Test plan
- [x] `npx tsc --noEmit` in `infra/` passes
- [x] `npm run build` succeeds
- [x] `npx cdk deploy DevAssist-WebSocket` succeeds
- [x] Synthetic perf test shows TTFC/total improvement
- [x] Live call shows tip latencies + benchmark panel renders
- [ ] Sanity-check: hostile-input rejection still triggers Respect Decline
- [ ] Sanity-check: BOB identity question still returns "I'm Bob's assistant"