### PR TITLE
v2.2.10: tip-latency benchmark + version bump

### DIFF
--- a/infra/lib/lambda/shared/claude-client-optimized.ts
+++ b/infra/lib/lambda/shared/claude-client-optimized.ts
@@ -199,11 +199,10 @@ export function getScriptsForStage(stage: string): string {
 
 export const SYSTEM_PROMPT_COMPRESSED = `Sales coach for local website design/SEO. Goal: get small business owner to agree to callback from Bob (senior designer agent assists).
 
-BOB: Senior local website designer. Agent is Bob's assistant. IDENTITY FRAMING:
-  - Default pitch/intro: "Bob and I are local website designers" (peer tone, never reveal hierarchy upfront)
-  - Direct identity question ("who are you?", "are you the owner?", "what's your role?", "are you Bob?"): honestly say "I'm Bob's assistant" or "I assist Bob with his clients"
-  - Never position Bob as a partner — always just "Bob" or "Bob and I"
-Bob handles pricing, technical details, and client consultations.
+BOB: Senior local website designer; agent is Bob's assistant. Bob handles pricing/technical/consultations.
+- Default intro/pitch: "Bob and I are local website designers" (peer tone, don't reveal hierarchy upfront).
+- Direct identity Q ("who are you?", "are you the owner?", "are you Bob?", "what's your role?") → honestly: "I'm Bob's assistant."
+- Never call Bob a partner.
 
 OUTPUT FORMAT (exactly):
 [HEADING]: 2-word title
@@ -217,13 +216,7 @@ TONE: Customer describes a problem → empathize first. NEVER say "that's great"
 
 INTENT RULES (priority order):
 1. AI/receptionist/voicemail → If they offer callback, ACCEPT and give Bob's number. Don't pitch an AI. Don't use Ask Callback for bots.
-1a. HOSTILE/FAKE INPUT → If customer provides info (email/name/phone/business) that contains:
-  - Profanity: "fuck", "shit", "piss", "dick", "ass", hostile variations
-  - Dismissals as placeholder: "none", "noemail", "leavemealone", "dontcall", "nope", "nothanks", "fakeemail", "whatever", "stop"
-  - Obvious fake names: "John Doe", "Jane Doe", "Mickey Mouse", single letters, profanity as names
-  - Reserved/fake phone: 555-0100 through 555-0199, 111-111-1111, 000-000-0000, 123-456-7890
-  - Repeated nonsense: "aaa@aaa.com", "xxx-xxx-xxxx"
-→ Treat as DECLINE + FRUSTRATION. DO NOT acknowledge as legitimate. DO NOT proceed to signoff. DO NOT mark info collected. Output Respect Decline script ("No problem. I do appreciate you taking my call. Have a great day."). End gracefully.
+1a. HOSTILE/FAKE info in email/name/phone/business (profanity, "none/noemail/nothanks/fakeemail/leavemealone/dontcall/whatever/stop", "John/Jane Doe"/cartoon names/single letters, 555-0100-0199/111-111-1111/000-000-0000/123-456-7890, "aaa@aaa.com", "xxx-xxx-xxxx") → Respect Decline: "No problem. I do appreciate you taking my call. Have a great day." Do NOT mark collected. Do NOT sign off.
 2. Customer agreed to callback (agent asked, customer said yes/sure/sounds good/go ahead, OR customer says "have Bob call me") → CONVERSION. Collect details. NEVER re-pitch.
    - Specific time given ("call at 4", "tomorrow") → acknowledge it, ask for email.
    - "Another time"/"busy right now" → ask WHEN, don't assume "later today".
@@ -245,45 +238,23 @@ INTENT RULES (priority order):
 17. "Send me an email" → Email Deflection — get email AND pivot to callback.
 18. Dry/vague/one-word answer → ENGAGEMENT script most relevant to context.
 
-CONVERSION STAGE RULES:
-- Customer agreed. Do NOT re-pitch. Collect: Name → Business Name → Email/Time → Sign Off (4 steps max).
-- We have their phone number (we dialed them). NEVER ask for it.
-- Always acknowledge what they JUST SAID before asking next question.
-- CHECK COLLECTED INFO: skip what's already collected.
-- customerName missing → "And your name is?"
-- businessName missing → "And what's the name of your business?"
-- email missing → "What's the best email and time to reach you at?"
-- all collected → Sign Off immediately.
-- Customer says "I already told you" → Sign Off IMMEDIATELY.
+CONVERSION (after agreement):
+- Do NOT re-pitch. Collect: Name → Business → Email/Time → Sign Off (4 steps max, skip what's collected).
+- We dialed them — NEVER ask for phone.
+- Acknowledge what they JUST SAID before the next question.
+- Missing name → "And your name is?" | Missing business → "And what's the name of your business?" | Missing email → "What's the best email and time to reach you at?" | All collected OR "I already told you" → Sign Off immediately.
 
-VALIDITY CHECK before treating any info as collected:
-- Email must look real (proper local@domain format, no profanity, no obvious dismissals)
-- Name must not be profanity, "John/Jane Doe", cartoon characters, or single letters
-- If hostile/fake info given → trigger rule 1a (Respect Decline), DO NOT mark as collected, DO NOT sign off.
+VALIDITY: Info counts as collected only if email is real (local@domain, no profanity/dismissals) AND name is real (not profanity/Doe/cartoons/single letters). Else → rule 1a.
 
 SIGNOFF: Output ONLY a Sign Off script. Bob will CALL THEM BACK — never say "call at your email".
 
-SCRIPT SELECTION:
-- Two parts: (1) SHORT acknowledgment of customer's LATEST message (max 15 words), (2) best golden script.
-- Tip MUST end with a question or callback ask.
-- Customer asks a question → answer IT first, then flow to golden script.
-- LATEST EXCHANGE: respond to what's happening NOW, not 5 messages ago.
-- Replace [Name]/[Location] with actual values if known.
-- No pricing numbers, no technical details — all Bob's job.
+SCRIPT: (1) short acknowledgment of LATEST message (≤15 words) + (2) best golden script. Must end with a question or callback ask. Customer asked → answer first, then script. Respond to NOW, not 5 msgs ago. Fill [Name]/[Location] if known. No pricing/technical — Bob's job.
 
-ANTI-REPETITION:
-- Check ALREADY SUGGESTED list — never repeat a listed script.
-- Intro done → never suggest intro again.
-- SEO pitched → don't pitch SEO again.
-- Callback asked → only ask again if context significantly changed.
-- Customer moved to new topic → answer NEW topic, not the old one.
-- Fallback: Ask Callback always advances the conversation.
+ANTI-REPETITION: Check ALREADY SUGGESTED — never repeat listed scripts. Intro done → no intro again. SEO pitched → no SEO repeat. Callback asked → only re-ask if context changed. Customer switched topics → answer NEW. Fallback: Ask Callback always advances.
 
-ESCALATION:
-- SEO pitched AND customer still objecting → softer Ask Callback.
-- SEO pitched AND callback asked AND still hesitant → Respect Decline. End gracefully.
+ESCALATION: SEO pitched + still objecting → softer Ask Callback. SEO + callback asked + still hesitant → Respect Decline.
 
-ESTABLISHED FACTS: Read the ESTABLISHED FACTS section. Never ask about things already known (website status, name, etc.). Identity: always "local website designers", never "digital marketing company".
+FACTS: Read ESTABLISHED FACTS; never ask about things already known. Identity: always "local website designers", never "digital marketing company".
 
 FRUSTRATION: "repeating", "already said that", "going in circles", "not answering", "runaround", "waste of time" → During conversion: Sign Off. Before conversion: acknowledge + Ask Callback.`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devassist-call-coach",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -25,7 +25,7 @@ console.log('🚀 [Background] Service worker started')
 // Import AWS WebSocket service for real-time coaching
 // Import AI Backend Service (Legacy Socket.io for Elastic Beanstalk fallback)
 import { awsWebSocketService } from '@/services/aws-websocket.service'
-import { saveTranscript, pruneOldTranscripts } from '@/utils/history-store'
+import { saveTranscript, pruneOldTranscripts, type HistoryTip } from '@/utils/history-store'
 
 // ============================================================================
 // TYPE DEFINITIONS
@@ -123,6 +123,11 @@ let keepAliveInterval: number | null = null
 let currentCallStartedAt: number | null = null;
 let currentCallDestination: string | null = null;
 
+// TEMP: benchmark-only — capture per-tip generation latency (first chunk → final tip)
+// Revert with the HistoryTip type + TranscriptDetail display after perf test is done.
+let pendingTipStartedAt: number | null = null;
+let currentCallTips: HistoryTip[] = [];
+
 async function saveCurrentCallToHistory(): Promise<void> {
   try {
     const transcripts = extensionState.transcriptions || [];
@@ -158,6 +163,7 @@ async function saveCurrentCallToHistory(): Promise<void> {
       transcript: finalEntries,
       intelligence: extensionState.latestIntelligence ?? null,
       entities: extensionState.latestEntities ?? null,
+      tips: currentCallTips.length > 0 ? currentCallTips : null,
     });
   } catch (err) {
     console.warn('[History] saveCurrentCallToHistory failed:', err);
@@ -300,6 +306,9 @@ chrome.runtime.onConnect.addListener(port => {
         currentCallDestination = message.destination || null
         extensionState.latestIntelligence = null
         extensionState.latestEntities = null
+        // TEMP benchmark: reset per-call tip accumulator
+        currentCallTips = []
+        pendingTipStartedAt = null
         if (currentCallDestination) {
           console.log(`📱 [Background] Destination captured from CALL_STARTED: ${currentCallDestination}`)
         }
@@ -615,6 +624,9 @@ async function processMessage(message: any, sender: any) {
       currentCallDestination = message.destination || null
       extensionState.latestIntelligence = null
       extensionState.latestEntities = null
+      // TEMP benchmark: reset per-call tip accumulator
+      currentCallTips = []
+      pendingTipStartedAt = null
       if (currentCallDestination) {
         console.log(`📱 [Background] Destination captured from CALL_STARTED: ${currentCallDestination}`)
       }
@@ -1148,6 +1160,10 @@ async function connectAIBackend() {
 
     // TIP_CHUNK: Forward streaming chunks to UI for progressive rendering
     awsWebSocketService.setTipChunkListener((delta, heading, stage) => {
+      // TEMP benchmark: first chunk of a new tip marks generation-start (client-visible)
+      if (pendingTipStartedAt === null) {
+        pendingTipStartedAt = Date.now();
+      }
       console.log(`🌊 [Background] Tip chunk: "${delta.substring(0, 20)}..."`);
       broadcastToUI({
         type: 'TIP_CHUNK',
@@ -1161,16 +1177,33 @@ async function connectAIBackend() {
         ? tip.options[0].script
         : '';
 
+      // TEMP benchmark: compute generation ms from first chunk → final tip
+      const generationMs = pendingTipStartedAt !== null
+        ? Date.now() - pendingTipStartedAt
+        : undefined;
+      pendingTipStartedAt = null;
+
       const tipPayload = {
         heading: tip.heading,
         stage: tip.stage,
         context: tip.context,
         suggestion: suggestion,
         recommendationId: tip.recommendationId,
-        timestamp: tip.timestamp
+        timestamp: tip.timestamp,
+        generationMs, // TEMP benchmark
       };
 
-      console.log('💡 [Background] AI Tip received — broadcasting final tip');
+      // TEMP benchmark: stash for history
+      currentCallTips.push({
+        heading: tip.heading,
+        stage: tip.stage,
+        context: tip.context,
+        suggestion,
+        timestamp: tip.timestamp || Date.now(),
+        generationMs,
+      });
+
+      console.log(`💡 [Background] AI Tip received — generationMs=${generationMs ?? 'n/a'}`);
       broadcastToUI({ type: 'AI_TIP', payload: tipPayload });
     })
 
@@ -1303,7 +1336,7 @@ async function connectAIBackend() {
       {
         source: 'devassist-call-coach',
         tabId: extensionState.tabId,
-        version: '2.2.9',
+        version: '2.2.10',
       }
     )
 

--- a/src/components/TranscriptDetail.tsx
+++ b/src/components/TranscriptDetail.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Phone, Download } from 'lucide-react';
-import type { CallHistoryRecord, HistoryIntelligence, HistoryEntities } from '@/utils/history-store';
+import type { CallHistoryRecord, HistoryIntelligence, HistoryEntities, HistoryTip } from '@/utils/history-store';
 import { downloadCallAsText, downloadCallAsJSON } from '@/utils/history-export';
 
 interface TranscriptDetailProps {
@@ -64,6 +64,7 @@ export function TranscriptDetail({ record, onBack }: TranscriptDetailProps) {
 
       <div className="flex-1 overflow-y-auto">
         <IntelligencePanel intelligence={record.intelligence} entities={record.entities} />
+        <TipsBenchmarkPanel tips={record.tips} />
 
         <div className="px-4 py-4 space-y-3">
           {record.transcript.length === 0 ? (
@@ -184,6 +185,61 @@ function formatWebsiteStatus(status: 'has_website' | 'no_website' | 'unknown' | 
   if (status === 'has_website') return 'Has website';
   if (status === 'no_website') return 'No website';
   return '--';
+}
+
+// ── TEMP: benchmark-only — AI Tips list with per-tip generation latency ──
+// Remove this panel (and the HistoryTip import + tips field) after the perf
+// benchmark data is collected.
+
+function TipsBenchmarkPanel({ tips }: { tips?: HistoryTip[] | null }) {
+  if (!tips || tips.length === 0) return null;
+
+  const withMs = tips.filter(t => typeof t.generationMs === 'number') as Array<HistoryTip & { generationMs: number }>;
+  const avgMs = withMs.length > 0
+    ? Math.round(withMs.reduce((sum, t) => sum + t.generationMs, 0) / withMs.length)
+    : null;
+
+  return (
+    <div className="px-4 py-3 bg-amber-50 dark:bg-amber-900/20 border-b border-amber-200 dark:border-amber-800">
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs font-semibold uppercase text-amber-700 dark:text-amber-300">
+          AI Tips (benchmark)
+        </div>
+        <div className="text-[11px] text-amber-700 dark:text-amber-300">
+          {tips.length} tip{tips.length === 1 ? '' : 's'}
+          {avgMs !== null && <span> · avg {avgMs}ms</span>}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {tips.map((tip, idx) => (
+          <div
+            key={idx}
+            className="rounded border border-amber-200 dark:border-amber-800 bg-white dark:bg-gray-900 px-3 py-2"
+          >
+            <div className="flex items-center justify-between gap-2 mb-1">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">
+                  {tip.heading || 'Tip'}
+                </span>
+                <span className="text-[10px] uppercase tracking-wide text-gray-500">
+                  {tip.stage}
+                </span>
+              </div>
+              <span className="shrink-0 text-[11px] font-mono px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200">
+                {typeof tip.generationMs === 'number' ? `${tip.generationMs}ms` : 'n/a'}
+              </span>
+            </div>
+            {tip.suggestion && (
+              <div className="text-sm text-gray-800 dark:text-gray-200">
+                {tip.suggestion}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 // Download helpers now live in @/utils/history-export (reused across views)

--- a/src/utils/history-store.ts
+++ b/src/utils/history-store.ts
@@ -36,6 +36,17 @@ export interface HistoryEntities {
   websiteStatus?: 'has_website' | 'no_website' | 'unknown';
 }
 
+// TEMP: benchmark-only — per-tip generation latency for perf measurement.
+// Remove after benchmark (along with background capture + TranscriptDetail display).
+export interface HistoryTip {
+  heading: string;
+  stage: string;
+  context?: string;
+  suggestion: string;
+  timestamp: number;
+  generationMs?: number;
+}
+
 export interface CallHistoryRecord {
   conversationId: string;
   agentEmail: string;
@@ -45,6 +56,7 @@ export interface CallHistoryRecord {
   transcript: HistoryTranscriptEntry[];
   intelligence?: HistoryIntelligence | null;
   entities?: HistoryEntities | null;
+  tips?: HistoryTip[] | null;
   savedAt: number;
   schemaVersion: number;
 }
@@ -103,6 +115,7 @@ export async function saveTranscript(params: {
   transcript: HistoryTranscriptEntry[];
   intelligence?: HistoryIntelligence | null;
   entities?: HistoryEntities | null;
+  tips?: HistoryTip[] | null;
 }): Promise<boolean> {
   try {
     if (!params.conversationId) {
@@ -124,6 +137,7 @@ export async function saveTranscript(params: {
       transcript: params.transcript,
       intelligence: params.intelligence ?? null,
       entities: params.entities ?? null,
+      tips: params.tips ?? null,
       savedAt: Date.now(),
       schemaVersion: CURRENT_SCHEMA,
     };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 const manifest: ManifestV3Export = {
   manifest_version: 3,
   name: "Simple.biz Call Coach",
-  version: "2.2.9",
+  version: "2.2.10",
   description: "Real-time AI-powered call coaching with AWS Lambda backend, conversation intelligence, and Developer Mode for offline testing",
   icons: {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Why a second PR

PR #74 was merged with only the first commit (prompt compression). The follow-up commits for the tip-latency benchmark and the 2.2.9 → 2.2.10 version bump landed on this branch after the merge, so they never reached main. Chrome Web Store deploy then failed with \`PKG_INVALID_VERSION_NUMBER\` because \`manifest: 2.2.9\` is already published.

This PR carries those two orphaned commits:
- \`10d5171\` — chore(debug): add tip-latency benchmark panel to history detail
- \`ad646c6\` — chore: bump version to 2.2.10

## What's in it

### 1. v2.2.10 version bump
Unblocks the Chrome Web Store upload. Bumped in \`package.json\`, \`vite.config.ts\`, and \`src/background/index.ts\`.

### 2. Tip-latency benchmark panel (TEMPORARY)
Amber "AI Tips (benchmark)" panel at the top of history transcript detail, listing every tip generated during a call with its per-tip generation ms badge. Marked \`// TEMP benchmark\` in three touch points for a clean revert later:
- \`src/utils/history-store.ts\` — \`HistoryTip\` type + \`tips\` field
- \`src/background/index.ts\` — latency clock + per-call tip accumulator
- \`src/components/TranscriptDetail.tsx\` — \`TipsBenchmarkPanel\` component

Measurement: clock from first \`TIP_CHUNK\` → final \`AI_TIP\` (client-visible streaming duration).

**Live-call data from initial test (4 tips)**:
- 3 of 4 tips in 930-1980ms band
- Median ~1369ms

## Test plan
- [x] \`npm run build\` succeeds
- [x] Live call shows tip latencies + benchmark panel renders
- [x] CI: Chrome Web Store upload succeeds with new version