### PR TITLE
hotfix: v2.2.11 — bake rotated Deepgram API key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devassist-call-coach",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1336,7 +1336,7 @@ async function connectAIBackend() {
       {
         source: 'devassist-call-coach',
         tabId: extensionState.tabId,
-        version: '2.2.10',
+        version: '2.2.11',
       }
     )
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 const manifest: ManifestV3Export = {
   manifest_version: 3,
   name: "Simple.biz Call Coach",
-  version: "2.2.10",
+  version: "2.2.11",
   description: "Real-time AI-powered call coaching with AWS Lambda backend, conversation intelligence, and Developer Mode for offline testing",
   icons: {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary
- Bumps version 2.2.10 → 2.2.11 across `package.json`, `vite.config.ts`, and `src/background/index.ts`
- Forces CI rebuild so the rotated `VITE_DEEPGRAM_API_KEY` GitHub Actions secret gets baked into the extension bundle
- Satisfies Chrome Web Store's unique-version requirement (2.2.10 already published)

## Context
Production agents started seeing Deepgram WebSocket cycling `error → disconnected` on every call, producing zero transcripts and zero AI tips. Background log showed plenty of audio flowing and AI backend connected cleanly — the failure was isolated to Deepgram auth. Key was rotated in GitHub Actions secrets; this PR triggers the rebuild.

No code changes — version bumps only.

## Test plan
- [x] CI deploy workflow completes successfully (build + Chrome Web Store upload + publish)
- [x] Reload extension, place a test call on CallTools
- [x] Offscreen console shows Deepgram connecting cleanly (no error cycles)
- [x] Side panel shows live transcript
- [x] AI tips fire during the call
- [x] History entry saves with transcript + tips