### PR TITLE
fix: correct AudioWorklet sample rate for non-48kHz devices (v2.2.13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,13 @@ npm-debug.log*
 # Manual test scripts with credentials
 tests/manual/reload-test-contact.cjs
 
+# Local-only request drafts
+doc/requests/2026-05-12-intro-usage-request.md
+
+# Local build/source archives (never commit)
+*.rar
+*.zip
+
 # Claude Code / god-mode (local only, never commit)
 .claude/
 .bmad/

--- a/doc/eod/2026-05-21-call-coach-EOD.md
+++ b/doc/eod/2026-05-21-call-coach-EOD.md
@@ -1,0 +1,64 @@
+# Call Coach Chrome Extension — End of Day Report
+
+**Date:** May 21, 2026
+**Developer:** Kayser B
+**Project:** DevAssist-Call-Coach
+**Version:** 2.2.12 → **2.2.13**
+
+---
+
+## Session Overview
+
+**Focus:** Bug fix — Deepgram produced zero transcripts for one specific agent (Gray) despite a healthy WebSocket connection and confirmed audio flow.
+
+**Outcome:** Root-cause fix in the AudioWorklet downsampler. Verified working for the affected agent. Version bumped to 2.2.13.
+
+---
+
+## Accomplishments
+
+### ✅ AudioWorklet sample-rate fix (v2.2.13)
+
+**Problem:** For one agent (Gray), Call Coach connected to Deepgram successfully and the audio monitor showed clear levels (jumping to ~50% when the agent spoke), but **no transcripts were ever produced**. Every other agent transcribed normally. The same mic transcribed fine on dictation.io, ruling out the microphone, OS audio settings, and any virtual audio drivers.
+
+**Root cause:** The AudioWorklet downsampler in `src/offscreen/audio-worklet-processor.js` assumed a native sample rate of 48000 Hz:
+
+```js
+this.nativeSampleRate = options.processorOptions?.sampleRate || 48000;
+```
+
+The bridge in `src/offscreen/index.ts` **never passes `sampleRate`** in `processorOptions`, so this always fell back to 48000. On Gray's machine (Realtek audio defaulting to **44100 Hz**), the AudioContext actually ran at 44.1 kHz. The downsample ratio was computed as `Math.round(48000 / 16000) = 3`, producing output at `44100 / 3 = 14700 Hz` while labeling it as 16000 Hz to Deepgram — an **8.8% pitch/speed shift** that rendered the audio unintelligible to the speech model. Deepgram received valid audio and stayed connected, but couldn't recognize any words.
+
+**Fix (`src/offscreen/audio-worklet-processor.js`):**
+
+1. **Read the AudioContext's actual sample rate** — use the `sampleRate` global available in `AudioWorkletGlobalScope` instead of a value that was never passed. The worklet now knows whether it's running at 44100, 48000, or any other rate.
+
+2. **Fractional downsampling with linear interpolation** — replaced naive decimation (`channelData[i * ratio]`, which only works for integer ratios) with linear interpolation, so fractional ratios like `44100 / 16000 = 2.75625` produce correctly-timed samples instead of running fast.
+
+**Regression safety:** For agents already on 48 kHz the ratio is exactly 3.0 and the interpolation degenerates to picking the same samples as before — behavior is unchanged. Only mismatched-rate machines (like Gray's 44.1 kHz) are corrected.
+
+**Verification:** Gray made a test call on the new build and transcripts now appear correctly. The new diagnostic log line (`[AudioWorklet] Initialized for agent: <rate>Hz → 16000Hz (ratio=...)`) confirms the true device sample rate on each call.
+
+**Files touched:** `src/offscreen/audio-worklet-processor.js` (fix) + version bump in `package.json`, `vite.config.ts`, `src/background/index.ts`. Also ignored local `*.rar`/`*.zip` archives in `.gitignore`.
+
+---
+
+## Deployment Notes
+
+- **CI/CD:** Deploy workflow fires on push to `main` — the version bump in the squash commit triggers a full rebuild + Chrome Web Store upload + publish.
+
+---
+
+## Agent Update Message
+
+> Call Coach v2.2.13 is live! Reload the extension to get the update.
+>
+> What's new:
+>
+> 🔧 Fixed — For a small number of agents, the live call was connecting but no transcription was appearing. This was caused by a mismatch in how the audio was processed on certain audio devices. Transcription now works correctly regardless of your sound hardware.
+>
+> To update:
+>
+> Go to Manage extensions.
+> On the upper left click the 'Update' Button.
+> Once the popup message on the lower left says 'Extensions Updated' then you're good to go. Happy call-coachin everyone!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devassist-call-coach",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1336,7 +1336,7 @@ async function connectAIBackend() {
       {
         source: 'devassist-call-coach',
         tabId: extensionState.tabId,
-        version: '2.2.12',
+        version: '2.2.13',
       }
     )
 

--- a/src/offscreen/audio-worklet-processor.js
+++ b/src/offscreen/audio-worklet-processor.js
@@ -23,12 +23,15 @@ class DeepgramAudioProcessor extends AudioWorkletProcessor {
     this.frameCount = 0;
     this.audioChunksSent = 0;
 
-    // Get native sample rate from options
-    this.nativeSampleRate = options.processorOptions?.sampleRate || 48000;
+    // Use the AudioContext's ACTUAL sample rate (global in AudioWorkletGlobalScope),
+    // not a value passed in options. The bridge never passes sampleRate, so the old
+    // code silently fell back to 48000 — wrong on Realtek devices that default to 44100,
+    // producing audio Deepgram cannot recognize.
+    this.nativeSampleRate = sampleRate;
     this.source = options.processorOptions?.source || 'unknown'; // 'agent' or 'caller'
-    this.downsampleRatio = Math.round(this.nativeSampleRate / this.targetSampleRate);
+    this.downsampleRatio = this.nativeSampleRate / this.targetSampleRate; // fractional, e.g. 44100/16000 = 2.75625
 
-    console.log(`[AudioWorklet] Initialized for ${this.source}: ${this.nativeSampleRate}Hz → ${this.targetSampleRate}Hz`);
+    console.log(`[AudioWorklet] Initialized for ${this.source}: ${this.nativeSampleRate}Hz → ${this.targetSampleRate}Hz (ratio=${this.downsampleRatio.toFixed(4)})`);
 
     // Handle messages from main thread
     this.port.onmessage = (event) => {
@@ -73,12 +76,18 @@ class DeepgramAudioProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    // Downsample to 16kHz (Mono)
+    // Downsample to 16kHz with linear interpolation so fractional ratios
+    // (e.g. 44100→16000 = 2.75625) produce correctly-timed samples instead
+    // of running 8.8% fast and being unintelligible to Deepgram.
     const downsampledLength = Math.floor(channelData.length / this.downsampleRatio);
     const downsampled = new Float32Array(downsampledLength);
 
     for (let i = 0; i < downsampledLength; i++) {
-        downsampled[i] = channelData[i * this.downsampleRatio];
+        const srcIndex = i * this.downsampleRatio;
+        const srcLower = Math.floor(srcIndex);
+        const srcUpper = Math.min(srcLower + 1, channelData.length - 1);
+        const frac = srcIndex - srcLower;
+        downsampled[i] = channelData[srcLower] * (1 - frac) + channelData[srcUpper] * frac;
     }
 
     // Convert Float32 to PCM 16-bit

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 const manifest: ManifestV3Export = {
   manifest_version: 3,
   name: "Simple.biz Call Coach",
-  version: "2.2.12",
+  version: "2.2.13",
   description: "Real-time AI-powered call coaching with AWS Lambda backend, conversation intelligence, and Developer Mode for offline testing",
   icons: {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary

Fixes Deepgram producing **zero transcripts for one specific agent** (Gray) despite a healthy WebSocket connection and confirmed audio flow. The same mic transcribed fine on dictation.io, ruling out the microphone, OS audio, and virtual audio drivers — the bug was entirely in our audio pipeline.

## Root cause

The AudioWorklet downsampler (`src/offscreen/audio-worklet-processor.js`) assumed a native sample rate of 48000 Hz:

```js
this.nativeSampleRate = options.processorOptions?.sampleRate || 48000;
```

The bridge in `src/offscreen/index.ts` **never passes `sampleRate`**, so this always fell back to 48000. On Gray's machine (Realtek audio defaulting to **44100 Hz**), the AudioContext actually ran at 44.1 kHz. The downsample ratio computed as `Math.round(48000 / 16000) = 3`, producing output at `44100 / 3 = 14700 Hz` while labeling it 16000 Hz to Deepgram — an **8.8% speed/pitch shift** that left the audio unintelligible to the speech model. Deepgram stayed connected and received valid audio, but recognized no words.

## Fix

1. **Read the AudioContext's actual sample rate** via the `sampleRate` global available in `AudioWorkletGlobalScope`, instead of a value that's never passed.
2. **Fractional downsampling with linear interpolation** — replaces naive decimation (which only works for integer ratios) so fractional ratios like `44100 / 16000 = 2.75625` produce correctly-timed samples.

## Regression safety

For agents already on 48 kHz, the ratio is exactly 3.0 and the interpolation degenerates to picking the same samples as before — behavior is unchanged. Only mismatched-rate devices (like Gray's 44.1 kHz) are corrected.

## Verification

- ✅ `npm run build` passes
- ✅ Affected agent (Gray, 44.1 kHz) made a test call on this build — transcripts now appear correctly
- New diagnostic log line confirms the true device sample rate per call: `[AudioWorklet] Initialized for agent: <rate>Hz → 16000Hz (ratio=...)`

## Changes

- `src/offscreen/audio-worklet-processor.js` — the fix
- Version bump 2.2.12 → 2.2.13 (`package.json`, `vite.config.ts`, `src/background/index.ts`)
- `doc/eod/2026-05-21-call-coach-EOD.md` — EOD report
- `.gitignore` — ignore local `*.rar`/`*.zip` archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)
